### PR TITLE
ENH: Add check for compatibility DICOMS

### DIFF
--- a/src/protocol_qc/classes/series.py
+++ b/src/protocol_qc/classes/series.py
@@ -397,7 +397,20 @@ class TemplateSeries:
         # Check software version of scanner and set private fields accordingly
         private_fields: dict[str, tuple[int, int]]
         sop_class_uid: str = data["SOPClassUID"].repval
-        if sop_class_uid == "Enhanced MR Image Storage":
+        try:
+            if (
+                data["ConversionSourceAttributesSequence"][0][
+                    "ReferencedSOPClassUID"
+                ].repval
+                == "Enhanced MR Image Storage"
+            ):
+                was_enhanced: bool = True
+            else:
+                was_enhanced = False
+        except KeyError:
+            was_enhanced = False
+
+        if sop_class_uid == "Enhanced MR Image Storage" or was_enhanced:
             private_fields = {
                 "GradientMode": (0x0021, 0x1008),
                 "ParallelImagingAcceleration": (0x0021, 0x1009),


### PR DESCRIPTION
What DICOM fields are available for interrogation depend on the the software of the scanner, as well as the final DICOM format.
A scenario not currently handled is when XA software is used to create classic DICOMS ("compatibility mode" on the scanner).

This is the beginnings of a pull request to correctly handle this scenario. This will require multiple test data sets to try cover all cases.