### PR TITLE
Change syntax for header field checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,47 @@ mkdir logs
 ProtocolQC_<TAG>.sif templates/ DICOM/ --logs_dir logs/
 ```
 
+## Upgrading from v0.2.x
+
+Version 0.3.0 introduces a breaking change to the protocol template file format.
+Field comparison specifications, which previously used a two-key `"value"` / `"comparison"` dict,
+are now expressed as a single-key dict where the key is the comparison type:
+
+| Old format | New format |
+|---|---|
+| `{"value": X, "comparison": "exact"}` | `{"exactly": X}` |
+| `{"value": X, "comparison": "exact", "compulsory": false}` | `{"exactly_if_present": X}` |
+| `{"comparison": "absent"}` | `{"absent": null}` |
+| `{"value": X, "comparison": "regex"}` | `{"regex": X}` |
+| `{"value": [a, b], "comparison": "in_range"}` | `{"in_range": [a, b]}` |
+| `{"value": [...], "comparison": "in_set"}` | `{"in_set": [...]}` |
+
+A conversion script is provided at `src/protocol_qc/convert_template.py`
+to automatically migrate existing templates to the new format.
+The script requires Python 3.10 or later (the same requirement as the package itself)
+and has no additional dependencies.
+
+**Convert a single file** (writes a `.new.json` sidecar alongside the original):
+
+```ShellSession
+python3 src/protocol_qc/convert_template.py my_template.json
+```
+
+**Convert a single file in-place** (overwrites the original):
+
+```ShellSession
+python3 src/protocol_qc/convert_template.py --in-place my_template.json
+```
+
+**Convert every template in a directory in-place**:
+
+```ShellSession
+python3 src/protocol_qc/convert_template.py --in-place templates/
+```
+
+The script is idempotent: running it on a template that is already in the new format
+leaves the file unchanged.
+
 ## Limitations
 
 - No check is performed to ensure there is a one-to-one mapping between the *series* template matches and the data.

--- a/docs/building_a_template.md
+++ b/docs/building_a_template.md
@@ -59,31 +59,44 @@ The key is the name of the DICOM header field, as specified by [pydicom](https:/
 the corresponding value is a dictionary containing two keys. "value" stores the value to check against,
 along with the method of comparison stored in the "comparison" value.
 
-There are five types of comparison operators available:
-- `exact`
-- `regex`
+There are six types of comparison operators available:
+- `absent`
+- `exactly`
+- `exactly_if_present`
 - `in_range`
 - `in_set`
-- `absent`
-
-Note, if a regex comparison is performed on a list,
-for example ImageType,
-and the template list is shorter than the list extracted from the DICOM header,
-only the cells in the DICOM header list up to the range of the template list will be compared.
+- `regex`
 
 An example of a *fields* dictionary:
 ```json
 "fields": {
-  "SeriesDescription": {
-    "value": "t1w",
-    "comparison": "regex"
-  },
-  "SequenceName": {
-    "value": "*tfl3d1_16ns",
-    "comparison": "exact"
-  }
+  "SeriesDescription": { "regex": "t1w" },
+  "SequenceName": { "exactly": "*tfl3d1_16ns" }
 }
 ```
+
+Comparison `in_range` requires that the template define a list of two numerical values
+defining the (inclusive) lower and upper bounds of the respective numerical range.
+
+Comparison `in_set` requires that the template define a list of values.
+
+Comparisons `exactly`, `exactly_if_present`, `in_range` and `regex`
+may provide within the template a list of values, which will be interpreted as follows:
+-   `exactly`, `exactly_if_present`: 
+    -   If the template defines a list of strings,
+        then each item in the template list must appear in the list read from the header
+        and vice versa,
+        irrespective of order.
+    -   If the template defines a list of any other data type,
+        then items are compared in their respective orders for equivalence;
+        any items in one list but not the other will be considered a mismatch.
+-   `in_range`:
+    The template must define a list of lists,
+    where each item is a list of two numerical values
+    defining a numerical range as described above.
+-   `regex`:
+    Each item in the list must be a string defining a regular expression;
+    these  will be evaluated against the contents of the DICOM header in order.
 
 *fields* can be defined at any level of the template,
 and will be inherited by all template definitions lower in the hierarchy,
@@ -211,23 +224,23 @@ field to check, the value to check it against, as well as the comparison method.
 
 In the following example, the *tags* section of a protocol template is shown.
 The `protocol_version` and `scanner_type` tags use the `constant` method and therefore will always be generated,
-and have the values `v42` and `Apeture Science`, respectively.
+and have the values `v42` and `Aperture Science`, respectively.
 The tag `scanner_software` uses the `fill_with` method, and will be extracted from the DICOM header field `SoftwareVersions`.
 If it does not exist, "NOT FOUND" will be set.
 Finally, the tag `site` uses the `options` method.
-In this case, the DICOM header field `InsitutationName` is being checked, with the options for the tag being `Earth`, `Mars` and `Pluto`.
+In this case, the DICOM header field `InstitutionName` is being checked, with the options for the tag being `Earth`, `Mars` and `Pluto`.
 
 ```json
 {
   "GENERAL": {
     "tags": {
       "protocol_version": {
-      "type": "constant",
-      "tag": "v42"
+        "type": "constant",
+        "tag": "v42"
       },
       "scanner_type": {
         "type": "constant",
-        "tag": "Apeture Science"
+        "tag": "Aperture Science"
       },
       "scanner_software": {
         "type": "fill_with",
@@ -273,12 +286,12 @@ In this case, the DICOM header field `InsitutationName` is being checked, with t
   },
   "custom_tags": {
     "protocol_version": "v42",
-    "scanner": "Apeture Science",
+    "scanner": "Aperture Science",
     "scanner_software": "GLaDOS",
     "site": "Earth"
   },
   "protocol": {
-    "template_name": "v42_apeture_scanners.json",
+    "template_name": "v42_aperture_scanners.json",
     "protocol_match_score": 1.0,
     "has_issue": false,
     "correct_ordering": "yes",

--- a/docs/example_template.json
+++ b/docs/example_template.json
@@ -6,14 +6,13 @@
     },
     "fields": {
       "InstituteName": {
-        "value": "Scans R Us",
-        "comparison": "regex"
+        "regex": "Scans R Us"
       }
     },
     "tags": {
       "protocol_version": {
-      "type": "constant",
-      "tag": "v42"
+        "type": "constant",
+        "tag": "v42"
       },
       "scanner_type": {
         "type": "constant",
@@ -28,18 +27,18 @@
         "tag": {
           "Earth": {
             "field": "InstitutionName",
-            "value": "Earth Base",
-            "comparison": "exact"
+            "exactly": "Earth Base"
           },
           "Mars": {
             "field": "InstitutionName",
-            "value": ["Mars", "The Red Institute"],
-            "comparison": "in_set"
+            "in_set": [
+              "Mars",
+              "The Red Institute"
+            ]
           },
           "Pluto": {
             "field": "InstitutionName",
-            "value": "Pluto MRI Services",
-            "comparison": "regex"
+            "regex": "Pluto MRI Services"
           }
         }
       }
@@ -49,27 +48,22 @@
     "duplicates_allowed": false,
     "fields": {
       "SeriesDescription": {
-        "value": "t1w",
-        "comparison": "regex"
+        "regex": "t1w"
       },
       "SequenceName": {
-        "value": "*ppl3d1_42ns",
-        "comparison": "exact"
+        "exactly": "*ppl3d1_42ns"
       },
       "ScanOptions": {
-        "value": [
+        "exactly": [
           "IR",
           "WE"
-        ],
-        "comparison": "exact"
+        ]
       },
       "Rows": {
-        "value": 256,
-        "comparison": "exact"
+        "exactly": 256
       },
       "Columns": {
-        "value": 256,
-        "comparison": "exact"
+        "exactly": 256
       }
     },
     "series": {
@@ -78,13 +72,12 @@
         "share_fields": false,
         "fields": {
           "ImageType": {
-            "value": [
+            "exactly": [
               "ORIGINAL",
               "PRIMARY",
               "M",
               "ND"
-            ],
-            "comparison": "exact"
+            ]
           }
         }
       },
@@ -92,14 +85,13 @@
         "num_files": 192,
         "fields": {
           "ImageType": {
-            "value": [
+            "exactly": [
               "ORIGINAL",
               "PRIMARY",
               "M",
               "ND",
               "NORM"
-            ],
-            "comparison": "exact"
+            ]
           }
         }
       }
@@ -109,8 +101,7 @@
     "duplicates_allowed": false,
     "fields": {
       "SeriesDescription": {
-        "value": "DWI_Ax_AP_52Dir",
-        "comparison": "regex"
+        "regex": "DWI_Ax_AP_52Dir"
       }
     },
     "series": {
@@ -118,12 +109,10 @@
         "num_files": 2,
         "fields": {
           "ImageComments": {
-            "value": "Single-band reference SENSE1+",
-            "comparison": "exact"
+            "exactly": "Single-band reference SENSE1+"
           },
           "ScanningSequence": {
-            "value": "EP",
-            "comparison": "exact"
+            "exactly": "EP"
           }
         }
       },
@@ -131,46 +120,41 @@
         "num_files": 42,
         "fields": {
           "Rows": {
-            "value": 1280,
-            "comparison": "exact"
+            "exactly": 1280
           },
           "Columns": {
-            "value": 1280,
-            "comparison": "exact"
+            "exactly": 1280
           },
           "NumberOfImagesInMosaic": {
-            "value": 84,
-            "comparison": "exact"
+            "exactly": 84
           }
+        }
       },
       "phase": {
         "num_files": 42,
         "fields": {
           "Rows": {
-            "value": 1280,
-            "comparison": "exact"
+            "exactly": 1280
           },
           "Columns": {
-            "value": 1280,
-            "comparison": "exact"
+            "exactly": 1280
           },
           "NumberOfImagesInMosaic": {
-            "value": 84,
-            "comparison": "exact"
-          },
+            "exactly": 84
+          }
+        }
       },
       "PhysioLog": {
         "num_files": 1,
         "share_fields": false,
         "fields": {
           "ImageType": {
-            "value": [
+            "exactly": [
               "ORIGINAL",
               "PRIMARY",
               "RAWDATA",
               "PHYSIO"
-            ],
-            "comparison": "exact"
+            ]
           }
         }
       }
@@ -187,38 +171,32 @@
     },
     "fields": {
       "SeriesDescription": {
-        "value": "Pseudoword",
-        "comparison": "regex"
+        "regex": "Pseudoword"
       },
       "SequenceName": {
-        "value": "lpfid223_42",
-        "comparison": "exact"
+        "exactly": "lpfid223_42"
       },
       "Rows": {
-        "value": 80,
-        "comparison": "exact"
+        "exactly": 80
       },
       "Columns": {
-        "value": 72,
-        "comparison": "exact"
-      },
+        "exactly": 72
+      }
     },
     "series": {
       "SBref_mag": {
         "num_files": 3,
         "fields": {
           "ImageType": {
-            "value": [
+            "exactly": [
               "ORIGINAL",
               "PRIMARY",
               "FMRI",
               "NONE"
-            ],
-            "comparison": "exact"
+            ]
           },
           "ImageComments": {
-              "value": "Single-band reference SENSE1+",
-              "comparison": "regex"
+            "regex": "Single-band reference SENSE1+"
           }
         }
       },
@@ -226,21 +204,18 @@
         "num_files": 3,
         "fields": {
           "ComplexImageComponent": {
-            "value": "PHASE",
-            "comparison": "exact"
+            "exactly": "PHASE"
           },
           "ImageType": {
-            "value": [
+            "exactly": [
               "ORIGINAL",
               "PRIMARY",
               "FMRI",
               "NONE"
-            ],
-            "comparison": "exact"
+            ]
           },
           "ImageComments": {
-              "value": "Single-band reference SENSE1+",
-              "comparison": "regex"
+            "regex": "Single-band reference SENSE1+"
           }
         }
       },
@@ -248,15 +223,14 @@
         "num_files": 42,
         "fields": {
           "ImageTypeText": {
-            "value": [
+            "regex": [
               "ORIGINAL",
               "PRIMARY",
               "M",
               "MB",
               "TE",
               "ND"
-            ],
-            "comparison": "regex"
+            ]
           }
         }
       },
@@ -264,15 +238,14 @@
         "num_files": 42,
         "fields": {
           "ImageTypeText": {
-            "value": [
+            "regex": [
               "ORIGINAL",
               "PRIMARY",
               "P",
               "MB",
               "TE",
               "ND"
-            ],
-            "comparison": "regex"
+            ]
           }
         }
       },
@@ -281,8 +254,7 @@
         "share_fields": false,
         "fields": {
           "SeriesDescription": {
-            "value": "Pseudoword.*PhysioLog",
-            "comparison": "regex"
+            "regex": "Pseudoword.*PhysioLog"
           }
         }
       }
@@ -293,20 +265,16 @@
     "ignore_ordering": true,
     "fields": {
       "SeriesDescription": {
-        "value": "FMap_AxObl_AP-",
-        "comparison": "regex"
+        "regex": "FMap_AxObl_AP-"
       },
       "Rows": {
-        "value": 112,
-        "comparison": "exact"
+        "exactly": 112
       },
       "Columns": {
-        "value": 112,
-        "comparison": "exact"
+        "exactly": 112
       },
       "SequenceName": {
-        "value": "asdasd23_42",
-        "comparison": "exact"
+        "exactly": "asdasd23_42"
       }
     },
     "series": {
@@ -315,17 +283,15 @@
         "share_fields": false,
         "fields": {
           "SeriesDescription": {
-            "value": "FMap_AxObl_AP-",
-            "comparison": "regex"
+            "regex": "FMap_AxObl_AP-"
           },
           "ImageType": {
-            "value": [
+            "exactly": [
               "ORIGINAL",
               "PRIMARY",
               "OTHER",
               "NONE"
-            ],
-            "comparison": "exact"
+            ]
           }
         }
       },
@@ -333,14 +299,13 @@
         "num_files": 1,
         "fields": {
           "ImageTypeText": {
-            "value": [
+            "exactly": [
               "ORIGINAL",
               "PRIMARY",
               "M",
               "ND",
               "NORM"
-            ],
-            "comparison": "exact"
+            ]
           }
         }
       }
@@ -351,20 +316,16 @@
     "ignore_ordering": true,
     "fields": {
       "SeriesDescription": {
-        "value": "FMap_AxObl_AP_InvROPE(|-)",
-        "comparison": "regex"
+        "regex": "FMap_AxObl_AP_InvROPE(|-)"
       },
       "Rows": {
-        "value": 112,
-        "comparison": "exact"
+        "exactly": 112
       },
       "Columns": {
-        "value": 112,
-        "comparison": "exact"
+        "exactly": 112
       },
       "SequenceName": {
-        "value": "asdasd23_42",
-        "comparison": "exact"
+        "exactly": "asdasd23_42"
       }
     },
     "series": {
@@ -373,17 +334,15 @@
         "share_fields": false,
         "fields": {
           "SeriesDescription": {
-            "value": "FMap_AxObl_AP_InvROPE(|-)_PhysioLog",
-            "comparison": "regex"
+            "regex": "FMap_AxObl_AP_InvROPE(|-)_PhysioLog"
           },
           "ImageType": {
-            "value": [
+            "exactly": [
               "ORIGINAL",
               "PRIMARY",
               "OTHER",
               "NONE"
-            ],
-            "comparison": "exact"
+            ]
           }
         }
       },
@@ -391,14 +350,13 @@
         "num_files": 1,
         "fields": {
           "ImageTypeText": {
-            "value": [
+            "exactly": [
               "ORIGINAL",
               "PRIMARY",
               "M",
               "ND",
               "NORM"
-            ],
-            "comparison": "exact"
+            ]
           }
         }
       }

--- a/docs/tutorial/02_seriesdescription.md
+++ b/docs/tutorial/02_seriesdescription.md
@@ -203,26 +203,17 @@ Here is the corresponding section of the original template
   },
   "T2*-weighted multi-echo gradient echo": {
     "fields": {
-      "SeriesDescription": {
-        "value": "^t2s_megre.*",
-        "comparison": "regex"
-      }
+      "SeriesDescription": { "regex": "^t2s_megre.*" }
     },
     "series": {
       "Images": {
         "fields": {
-          "SeriesDescription": {
-            "value": "t2s_megre",
-            "comparison": "exact"
-          }
+          "SeriesDescription": { "exactly": "t2s_megre" }
         }
       },
       "R2* map": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_R2Star_Images$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_R2Star_Images$" }
         }
       }
     }
@@ -236,87 +227,32 @@ And here is the corresponding section of the revised protocol
   },
   "T2*-weighted multi-echo gradient echo": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*fl3d\\d+r",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^\\*fl3d\\d+r" },
     },
     "series": {
       "Magnitude (original)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND" ] }
         }
       },
       "Magnitude (normalised)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       },
       "Phase": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "P",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "P", "ND" ] }
         }
       },
       "R2* map": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "R2_STAR MAP",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "R2_STAR MAP", "ND", "NORM" ] }
         }
       }
     }

--- a/docs/tutorial/03_checkparams.md
+++ b/docs/tutorial/03_checkparams.md
@@ -81,7 +81,7 @@ within version 2 of the session template [`templates/02_bymetadata.json`](templa
       },
       "Magnitude (normalised)": {
         "fields": {
-          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" } }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       },
       "Phase": {

--- a/docs/tutorial/03_checkparams.md
+++ b/docs/tutorial/03_checkparams.md
@@ -29,41 +29,13 @@ the following was added:
 {
   "GENERAL": {
     "fields": {
-      "BodyPartExamined": {
-        "value": "BRAIN",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "AngioFlag": {
-        "value": "N",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "ImagedNucleus": {
-        "value": "1H",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "MagneticFieldStrength": {
-        "value": 3,
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "TransmitCoilName": {
-        "value": "Body",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "dBdt": {
-        "value": 0,
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "PatientPosition": {
-        "value": "HFS",
-        "comparison": "exact",
-        "compulsory": false
-      }
+      "BodyPartExamined": { "exactly_if_present": "BRAIN" },
+      "AngioFlag": { "exactly_if_present": "N" },
+      "ImagedNucleus": { "exactly_if_present": "1H" },
+      "MagneticFieldStrength": { "exactly_if_present": 3 },
+      "TransmitCoilName": { "exactly_if_present": "Body" },
+      "dBdt": { "exactly_if_present": 0 },
+      "PatientPosition": { "exactly_if_present": "HFS" }
     }
   },
 ```
@@ -71,8 +43,8 @@ the following was added:
 Conformity to these metadata fields is enforced for all acquisitions
 and therefore all series.
 One distinction here is that for each of these fields,
-an additional flag has been added that specifies that it is *not compulsory*
-for these fields to appear in the empirical metadata;
+the name of the comparison `"exactly_if_present"` implies
+that it is *not compulsory* for these fields to appear in the empirical metadata;
 that is, if that field is absent from the input data,
 that is *not* considered a mismatch against the template;
 it is only when that field is present,
@@ -94,87 +66,32 @@ within version 2 of the session template [`templates/02_bymetadata.json`](templa
   },
   "T2*-weighted multi-echo gradient echo": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*fl3d\\d+r",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^\\*fl3d\\d+r" }
     },
     "series": {
       "Magnitude (original)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND" ] }
         }
       },
       "Magnitude (normalised)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" } }
         }
       },
       "Phase": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "P",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "P", "ND" ] }
         }
       },
       "R2* map": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "R2_STAR MAP",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "R2_STAR MAP", "ND", "NORM" ] }
         }
       }
     }
@@ -189,183 +106,52 @@ in the new version of that acquisition template
   },
   "T2*-weighted multi-echo gradient echo": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*fl3d\\d+r",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 25,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": [
-          10,
-          15,
-          20
-        ],
-        "comparison": "in_set"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": [
-          1,
-          2,
-          3
-        ],
-        "comparison": "in_set"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 3,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 90.625,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 310,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          58
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 15,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 58,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3.59375,
-          3.59375
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Cor|C>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "Normal",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p3",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^\\*fl3d\\d+r" },
+      "SliceThickness": { "exactky": 5 },
+      "RepetitionTime": { "exactly": 25 },
+      "EchoTime": { "in_set": [ 10, 15, 20 ] },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "in_set": [ 1, 2, 3 ] },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 3 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 90.625 },
+      "PixelBandwidth": { "exactly": 310 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 58 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 15 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 58 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [ 3.59375, 3.59375 ] },
+      "PRIVATE-Orientation": { "regex": "^(Cor|C>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "Normal" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p3" }
     },
     "series": {
       "Magnitude (original)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND" ] }
         }
       },
       "Magnitude (normalised)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       },
       "Phase": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "P",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "P", "ND" ] }
         }
       },
       "R2* map": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "R2_STAR MAP",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "R2_STAR MAP", "ND", "NORM" ] }
         }
       }
     }

--- a/docs/tutorial/sessions/010.md
+++ b/docs/tutorial/sessions/010.md
@@ -163,10 +163,7 @@ into the protocol template by changing:
     },
     "Series": {
       "fields": {
-        "PRIVATE-BValue": {
-          "value": [0, 1000],
-          "comparison": "in_set"
-        },
+        "PRIVATE-BValue": { "in_set": [0, 1000] }
       }
     },
 ```
@@ -177,10 +174,7 @@ to:
     },
     "Series": {
       "fields": {
-        "PRIVATE-BValue": {
-          "value": [0, 5, 10, 15, 985, 990, 995, 1000, 1005, 1010, 1015],
-          "comparison": "in_set"
-        },
+        "PRIVATE-BValue": { "in_set": [0, 5, 10, 15, 985, 990, 995, 1000, 1005, 1010, 1015] }
       }
     },
 ```

--- a/docs/tutorial/templates/01_byseriesdescription.json
+++ b/docs/tutorial/templates/01_byseriesdescription.json
@@ -1,186 +1,122 @@
 {
   "Localizer": {
     "fields": {
-      "SeriesDescription": {
-        "value": "localizer",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "localizer" }
     },
     "series": {
-      "Image": {
-      }
+      "Image": { }
     }
   },
   "Dual echo gradient echo field map": {
     "fields": {
-      "SeriesDescription": {
-        "value": "gre_field_mapping",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "gre_field_mapping" }
     },
     "series": {
-      "PhaseDiff": {
-      }
+      "PhaseDiff": { }
     }
   },
   "T1-weighted FLASH": {
     "fields": {
-      "SeriesDescription": {
-        "value": "t1_fl2d_sag",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "t1_fl2d_sag" }
     },
     "series": {
-      "Image": {
-      }
+      "Image": { }
     }
   },
   "T2-weighted Turbo Spin Echo": {
     "fields": {
-      "SeriesDescription": {
-        "value": "t2_tse_tra_p2",
-        "comparison": "exact"
-      }
-    },
+      "SeriesDescription": { "exactly": "t2_tse_tra_p2" }
+     },
     "series": {
-      "Image": {
-      }
+      "Image": { }
     }
   },
   "MP2RAGE": {
     "fields": {
-      "SeriesDescription": {
-        "value": "^t1_mp2rage.*",
-        "comparison": "regex"
-      }
+      "SeriesDescription": { "exactly": "^t1_mp2rage.*" }
     },
     "series": {
       "First inversion": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_INV1$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_INV1$" }
         }
       },
       "Second inversion": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_INV2$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_INV2$" }
         }
       },
       "T1 map": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_T1_Images$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_T1_Images$" }
         }
       },
       "First simulated inversion time": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_T1_Images_SIM-TI410ms$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_T1_Images_SIM-TI410ms$" }
         }
       },
       "Second simulated inversion time": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_T1_Images_SIM-TI1100ms$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_T1_Images_SIM-TI1100ms$" }
         }
       },
       "Uniform intensity image": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_UNI_Images$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_UNI_Images$" }
         }
       },
       "Denoised uniform intensity image": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_UNI\\-DEN$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_UNI\\-DEN$" }
         }
       }
     }
   },
   "T2*-weighted multi-echo gradient echo": {
     "fields": {
-      "SeriesDescription": {
-        "value": "^t2s_megre.*",
-        "comparison": "regex"
-      }
+      "SeriesDescription": { "regex": "^t2s_megre.*" }
     },
     "series": {
       "Images": {
         "fields": {
-          "SeriesDescription": {
-            "value": "t2s_megre",
-            "comparison": "exact"
-          }
+          "SeriesDescription": { "exactly": "t2s_megre" }
         }
       },
       "R2* map": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_R2Star_Images$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_R2Star_Images$" }
         }
       }
     }
   },
   "Spin-echo EPI (product); A>>P": {
     "fields": {
-      "SeriesDescription": {
-        "value": "ep2d_se_ap",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "ep2d_se_ap" }
     },
     "series": {
-      "Image": {
-      }
+      "Image": { }
     }
   },
   "Spin-echo EPI (product); P>>A": {
     "fields": {
-      "SeriesDescription": {
-        "value": "ep2d_se_pa",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "ep2d_se_pa" }
     },
     "series": {
-      "Image": {
-      }
+      "Image": { }
     }
   },
   "Task-based fMRI BOLD": {
     "fields": {
-      "SeriesDescription": {
-        "value": "ep2d_fid_basic_bold_p2_task",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "ep2d_fid_basic_bold_p2_task" }
     },
     "series": {
-      "Image": {
-      }
+      "Image": { }
     }
   },
   "Resting-state fMRI BOLD": {
     "fields": {
-      "SeriesDescription": {
-        "value": "ep2d_fid_basic_bold_p2_rest",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "ep2d_fid_basic_bold_p2_rest" }
     },
     "series": {
       "Image": {
@@ -189,134 +125,88 @@
   },
   "Spin-echo EPI (CMRR); A>>P": {
     "fields": {
-      "SeriesDescription": {
-        "value": "cmrr_ep2d_se_ap",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "cmrr_ep2d_se_ap" }
     },
     "series": {
-      "Image": {
-      }
+      "Image": { }
     }
   },
   "Spin-echo EPI (CMRR); A>>P Inv-RO-PE": {
     "fields": {
-      "SeriesDescription": {
-        "value": "cmrr_ep2d_se_apinvrope",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "cmrr_ep2d_se_apinvrope" }
     },
     "series": {
-      "Image": {
-      }
+      "Image": { }
     }
   },
   "Diffusion MRI": {
     "fields": {
-      "SeriesDescription": {
-        "value": "^cmrr_mbep2d_diff.*",
-        "comparison": "regex"
-      }
+      "SeriesDescription": { "regex": "^cmrr_mbep2d_diff.*" }
     },
     "series": {
       "DWI": {
         "fields": {
-          "SeriesDescription": {
-            "value": "cmrr_mbep2d_diff",
-            "comparison": "exact"
-          }
+          "SeriesDescription": { "exactly": "cmrr_mbep2d_diff" }
         }
       },
       "ADC": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_ADC$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_ADC$" }
         }
       },
       "Trace-weighted": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_TRACEW$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_TRACEW$" }
         }
       },
       "Fractional Anisotropy": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_FA$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_FA$" }
         }
       },
       "Directionally-Encoded Colour FA": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_ColFA$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_ColFA$" }
         }
       },
       "Diffusion Tensor fit": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_TENSOR$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_TENSOR$" }
         }
       }
     }
   },
   "Pulsed Arterial Spin Labelling": {
     "fields": {
-      "SeriesDescription": {
-        "value": "^pasl_3d_tra.*",
-        "comparison": "regex"
-      }
+      "SeriesDescription": { "regex": "^pasl_3d_tra.*" }
     },
     "series": {
       "Images": {
         "fields": {
-          "SeriesDescription": {
-            "value": "pasl_3d_tra",
-            "comparison": "exact"
-          }
+          "SeriesDescription": { "exactly": "pasl_3d_tra" }
         }
       },
       "Perfusion-weighted": {
         "fields": {
-          "SeriesDescription": {
-            "value": ".*_Perfusion_Weighted$",
-            "comparison": "regex"
-          }
+          "SeriesDescription": { "regex": ".*_Perfusion_Weighted$" }
         }
       }
     }
   },
   "Spectroscopy": {
     "fields": {
-      "SeriesDescription": {
-        "value": "csi_slaser",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "csi_slaser" }
     },
     "series": {
-      "Data": {
-      }
+      "Data": { }
     }
   },
   "Phoenix Report": {
     "fields": {
-      "SeriesDescription": {
-        "value": "PhoenixZIPReport",
-        "comparison": "exact"
-      }
+      "SeriesDescription": { "exactly": "PhoenixZIPReport" }
     },
     "series": {
-      "Data": {
-      }
+      "Data": { }
     }
   }
 }

--- a/docs/tutorial/templates/02_bymetadata.json
+++ b/docs/tutorial/templates/02_bymetadata.json
@@ -1,1060 +1,373 @@
 {
   "Localizer": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*fl2d1",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": "^[lL]ocali[sz]er$",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR"},
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*fl2d1" },
+      "ProtocolName": { "regex": "^[lL]ocali[sz]er$" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       }
     }
   },
   "Dual echo gradient echo field map": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SP",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*fm2d2r",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": "SP" },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*fm2d2r" }
     },
     "series": {
       "PhaseDiff": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "P",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "P", "ND" ] }
         }
       }
     }
   },
   "T1-weighted FLASH": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*fl2d1",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": "^(?![lL]ocali[sz]er)",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*fl2d1" },
+      "ProtocolName": { "regex": "^(?![lL]ocali[sz]er)" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       }
     }
   },
   "T2-weighted Turbo Spin Echo": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "SE",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*tse2d1_\\d+$",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "SE" },
+      "SequenceVariant": { "exactly": [ "SK", "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "regex": "^\\*tse2d1_\\d+$" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       }
     }
   },
   "MP2RAGE": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": [
-          "GR",
-          "IR"
-        ],
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP",
-          "MP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "IR",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^(WIP_|)cmp3d1_\\d+ns$",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": [ "GR", "IR" ] },
+      "SequenceVariant": { "exactly": [ "SK", "SP", "MP" ] },
+      "ScanOptions": { "exactly": "IR" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^(WIP_|)cmp3d1_\\d+ns$" }
     },
     "series": {
       "First inversion": {
         "fields": {
-          "ImageType": {
-            "value": [
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "M",
-                "ND",
-                "NORM"
-              ],
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "P",
-                "ND"
-              ]
-            ],
-            "comparison": "in_set"
-          },
-          "ImageComments": {
-            "value": "Inv1 Image",
-            "comparison": "exact"
-          }
+          "ImageType": { "in_set": [ ["ORIGINAL", "PRIMARY", "M", "ND", "NORM"],
+                                     ["ORIGINAL", "PRIMARY", "P", "ND"] ] },
+          "ImageComments": { "exactly": "Inv1 Image" }
         }
       },
       "Second inversion": {
         "fields": {
-          "ImageType": {
-            "value": [
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "M",
-                "ND",
-                "NORM"
-              ],
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "P",
-                "ND"
-              ]
-            ],
-            "comparison": "in_set"
-          },
-          "ImageComments": {
-            "value": "Inv2 Image",
-            "comparison": "exact"
-          }
+          "ImageType": { "in_set": [ ["ORIGINAL", "PRIMARY", "M", "ND", "NORM"],
+                                     ["ORIGINAL", "PRIMARY", "P", "ND"] ] },
+          "ImageComments": { "exactly": "Inv2 Image" }
         }
       },
       "T1 map": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "T1 MAP",
-              "ND"
-            ],
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "T1 Map",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "T1 MAP", "ND" ] },
+          "ImageComments": { "exactly": "T1 Map" }
         }
       },
       "Simulated inversion time": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Simulated T1 Contrast",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND"] },
+          "ImageComments": { "exactly": "Simulated T1 Contrast" }
         },
         "duplicates_expected": 2
       },
       "Uniform intensity image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND",
-              "UNI"
-            ],
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Uniform Image",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": ["DERIVED", "PRIMARY", "M", "ND", "UNI"] },
+          "ImageComments": { "exactly": "Uniform Image" }
         }
       },
       "Denoised uniform intensity image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND",
-              "UNI"
-            ],
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "^Denoised Image \\(lambda = \\d+(\\.\\d+)?\\)$",
-            "comparison": "regex"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND", "UNI" ] },
+          "ImageComments": { "regex": "^Denoised Image \\(lambda = \\d+(\\.\\d+)?\\)$" }
         }
       }
     }
   },
   "T2*-weighted multi-echo gradient echo": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*fl3d\\d+r",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^\\*fl3d\\d+r" }
     },
     "series": {
       "Magnitude (original)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": ["ORIGINAL", "PRIMARY", "M", "ND" ] }
         }
       },
       "Magnitude (normalised)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": ["ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       },
       "Phase": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "P",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "P", "ND" ] }
         }
       },
       "R2* map": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "R2_STAR MAP",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "R2_STAR MAP", "ND", "NORM" ] }
         }
       }
     }
   },
   "Spin-echo EPI (product); A>>P": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "^.*(_ap|A>>P)$",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SP" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*ep_b0" },
+      "SeriesDescription": { "regex": "^.*(_ap|A>>P)$" }
     },
     "duplicates_expected": 2,
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
   },
   "Spin-echo EPI (product); P>>A": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "^.*(_pa|P>>A)$",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SP" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*ep_b0" },
+      "SeriesDescription": { "regex": "^.*(_pa|P>>A)$" }
     },
     "duplicates_expected": 2,
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
   },
   "Task-based fMRI BOLD": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SK",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*epfid2d\\d+_\\d+$",
-        "comparison": "regex"
-      },
-      "SeriesDescription": {
-        "value": "[\\W]*(task|Task|TASK)",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": "SK" },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "regex": "^\\*epfid2d\\d+_\\d+$" },
+      "SeriesDescription": { "regex": "[\\W]*(task|Task|TASK)" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "PERFUSION",
-              "NONE",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "PERFUSION", "NONE", "ND" ] }
         }
       }
     }
   },
   "Resting-state fMRI BOLD": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SK",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*epfid2d\\d+_\\d+$",
-        "comparison": "regex"
-      },
-      "SeriesDescription": {
-        "value": "[\\W]*(rest|Rest|REST)",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": "SK" },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "regex": "^\\*epfid2d\\d+_\\d+$" },
+      "SeriesDescription": { "regex": "[\\W]*(rest|Rest|REST)" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "PERFUSION",
-              "NONE",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "PERFUSION", "NONE", "ND"] }
         }
       }
     }
   },
   "Spin-echo EPI (CMRR); A>>P": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SS"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "^.*(_ap|A>>P)$",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SS" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "ep_b0" },
+      "SeriesDescription": { "regex": "^.*(_ap|A>>P)$" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
   },
   "Spin-echo EPI (CMRR); A>>P Inv-RO-PE": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SS"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "[\\W_]?[iI][nN][vV][\\W_]?[rR][oO][\\W_]?[pP][eE]",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SS" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "ep_b0" },
+      "SeriesDescription": { "regex": "[\\W_]?[iI][nN][vV][\\W_]?[rR][oO][\\W_]?[pP][eE]" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
   },
   "Diffusion MRI": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SS"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": [
-          "PFP",
-          "FS"
-        ],
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SS" ] },
+      "ScanOptions": { "exactly": [ "PFP", "FS" ] },
+      "MRAcquisitionType": { "exactly": "2D" }
     },
     "series": {
       "DWI magnitude": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+#\\d+$",
-            "comparison": "regex"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM", "MOSAIC" ] },
+          "SequenceName": { "regex": "^ep_b\\d+#\\d+$" }
         }
       },
       "DWI phase": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+#\\d+$",
-            "comparison": "regex"
-          }
+          "ImageType": { "exactly": ["ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "MOSAIC" ] },
+          "SequenceName": { "regex": "^ep_b\\d+#\\d+$" }
         }
       },
       "ADC": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "DIFFUSION",
-              "ADC",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b0_\\d+$",
-            "comparison": "regex"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "ADC", "ND", "NORM" ] },
+          "SequenceName": { "regex": "^ep_b0_\\d+$" }
         }
       },
       "Trace-weighted": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "DIFFUSION",
-              "TRACEW",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+t$",
-            "comparison": "regex"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "TRACEW", "ND", "NORM" ] },
+          "SequenceName": { "regex": "^ep_b\\d+t$" }
         }
       },
       "Fractional Anisotropy": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "DIFFUSION",
-              "FA",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b0_\\d+$",
-            "comparison": "regex"
-          },
-          "SamplesPerPixel": {
-            "value": 1,
-            "comparison": "exact"
-          },
-          "PhotometricInterpretation": {
-            "value": "MONOCHROME2",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "FA", "ND", "NORM" ] },
+          "SequenceName": { "regex": "^ep_b0_\\d+$" },
+          "SamplesPerPixel": { "exactly": 1 },
+          "PhotometricInterpretation": { "exactly": "MONOCHROME2" }
         }
       }
     }
   },
   "Directionally-Encoded Colour FA": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ImageType": {
-        "value": [
-          "DERIVED",
-          "PRIMARY",
-          "DIFFUSION",
-          "FA",
-          "ND",
-          "NORM"
-        ],
-        "comparison": "exact"
-      },
-      "SamplesPerPixel": {
-        "value": 3,
-        "comparison": "exact"
-      },
-      "PhotometricInterpretation": {
-        "value": "RGB",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "FA", "ND", "NORM" ] },
+      "SamplesPerPixel": { "exactly": 3 },
+      "PhotometricInterpretation": { "exactly": "RGB" }
     },
     "series": {
-      "Images": {
-      }
+      "Images": { }
     }
   },
   "Diffusion Tensor": {
     "fields": {
-      "ImageType": {
-        "value": [
-          "DERIVED",
-          "PRIMARY",
-          "DIFFUSION",
-          "TENSOR",
-          "ND",
-          "NORM"
-        ],
-        "comparison": "exact"
-      },
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ImageComments": {
-        "value": "DTI Tensor",
-        "comparison": "exact"
-      }
+      "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "TENSOR", "ND", "NORM" ] },
+      "Modality": { "exactly": "MR" },
+      "ImageComments": { "exactly": "DTI Tensor" }
     },
     "series": {
-      "Data": {
-      }
+      "Data": { }
     }
   },
   "Pulsed Arterial Spin Labelling": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SK",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*tgse3d1_\\d+$",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": "SK" },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^\\*tgse3d1_\\d+$" }
     },
     "series": {
       "Images": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "ASL",
-              "NONE",
-              "NORM",
-              "DIS2D",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "ASL", "NONE", "NORM", "DIS2D", "MOSAIC" ] }
         }
       },
       "Perfusion-weighted": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "ASL",
-              "NORM",
-              "DIS2D",
-              "SUB",
-              "TTEST",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "ASL", "NORM", "DIS2D", "SUB", "TTEST", "MOSAIC" ] }
         }
       }
     }
   },
   "Spectroscopy": {
     "fields": {
-      "ImageType": {
-        "value": [
-          "ORIGINAL",
-          "PRIMARY"
-        ],
-        "comparison": "exact"
-      },
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": [
-          "csi_slaser",
-          "Spectroscopy"
-        ],
-        "comparison": "in_set"
-      },
-      "ImageComments": {
-        "value": "^_pwc_\\d+$",
-        "comparison": "regex"
-      }
+      "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY" ] },
+      "Modality": { "exactly": "MR" },
+      "ProtocolName": { "in_set": [ "csi_slaser", "Spectroscopy" ] },
+      "ImageComments": { "regex": "^_pwc_\\d+$" }
     },
     "series": {
-      "Data": {
-      }
+      "Data": { }
     }
   },
   "Phoenix Report": {
     "fields": {
-      "ImageType": {
-        "value": [
-          "ORIGINAL",
-          "PRIMARY",
-          "OTHER",
-          "CSA REPORT"
-        ],
-        "comparison": "exact"
-      },
-      "Modality": {
-        "value": "SR",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": "Phoenix Document",
-        "comparison": "exact"
-      }
+      "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "OTHER", "CSA REPORT" ] },
+      "Modality": { "exactly": "SR" },
+      "ProtocolName": { "exactly": "Phoenix Document" }
     },
     "series": {
-      "Data": {
-      }
+      "Data": { }
     }
   }
 }
+

--- a/docs/tutorial/templates/03_checkparams.json
+++ b/docs/tutorial/templates/03_checkparams.json
@@ -1,2408 +1,687 @@
 {
   "GENERAL": {
     "fields": {
-      "BodyPartExamined": {
-        "value": "BRAIN",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "AngioFlag": {
-        "value": "N",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "ImagedNucleus": {
-        "value": "1H",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "MagneticFieldStrength": {
-        "value": 3,
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "TransmitCoilName": {
-        "value": "Body",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "dBdt": {
-        "value": 0,
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "PatientPosition": {
-        "value": "HFS",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "PRIVATE-CoilElementsUsed": {
-        "value": "HE1-4",
-        "comparison": "exact",
-        "compulsory": false
-      }
+      "BodyPartExamined": { "exactly_if_present": "BRAIN" },
+      "AngioFlag": { "exactly_if_present": "N" },
+      "ImagedNucleus": { "exactly_if_present": "1H" },
+      "MagneticFieldStrength": { "exactly_if_present": 3 },
+      "TransmitCoilName": { "exactly_if_present": "Body" },
+      "dBdt": { "exactly_if_present": 0 },
+      "PatientPosition": { "exactly_if_present": "HFS" },
+      "PRIVATE-CoilElementsUsed": { "exactly_if_present": "HE1-4" }
     }
   },
   "Localizer": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*fl2d1",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": "^[lL]ocali[sz]er$",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*fl2d1" },
+      "ProtocolName": { "regex": "^[lL]ocali[sz]er$" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       }
     }
   },
   "Dual echo gradient echo field map": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SP",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*fm2d2r",
-        "comparison": "exact"
-      },
-      "SliceThickness": {
-        "value": 6,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 200,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 7.38,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 2,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 7.5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 0,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 290,
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "ROW",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "Fast",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "comparison": "absent",
-        "compulsory": false
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": "SP" },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*fm2d2r" },
+      "SliceThickness": { "exactly": 6 },
+      "RepetitionTime": { "exactly": 200 },
+      "EchoTime": { "exactly": 7.38 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 2 },
+      "SpacingBetweenSlices": { "exactly": 7.5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 64 },
+      "EchoTrainLength": { "exactly": 0 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 290 },
+      "InPlanePhaseEncodingDirection": { "exactly": "ROW" },
+      "FlipAngle": { "exactly": 60 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [ 3, 3 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "Fast" },
+      "PRIVATE-ParallelImagingAcceleration": { "absent": null }
     },
     "series": {
       "PhaseDiff": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "P",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "P", "ND" ] }
         }
       }
     }
   },
   "T1-weighted FLASH": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*fl2d1",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": "^(?![lL]ocali[sz]er)",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 6,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 2.46,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 7.8,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 167,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 80,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 320,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          0,
-          160,
-          128,
-          0
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "ROW",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 70,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 160,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 160,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.375,
-          1.375
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Sag|S>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "comparison": "absent",
-        "compulsory": false
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*fl2d1" },
+      "ProtocolName": { "regex": "^(?![lL]ocali[sz]er)" },
+      "SliceThickness": { "exactly": 6 },
+      "RepetitionTime": { "exactly": 100 },
+      "EchoTime": { "exactly": 2.46 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 7.8 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 167 },
+      "EchoTrainLength": { "exactly": 1 },
+      "PercentSampling": { "exactly": 80 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 320 },
+      "AcquisitionMatrix": { "exactly": [ 0, 160, 128, 0 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "ROW" },
+      "FlipAngle": { "exactly": 70 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 160 },
+      "Columns": { "exactly": 160 },
+      "PixelSpacing": { "exactly": [ 1.375, 1.375 ] },
+      "PRIVATE-Orientation": { "regex": "^(Sag|S>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "absent": null }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       }
     }
   },
   "T2-weighted Turbo Spin Echo": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "SE",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*tse2d1_\\d+$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 6,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 26,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 7.8,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 166,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 17,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 220,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          0,
-          128,
-          128,
-          0
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "ROW",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 150,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 256,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 256,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          0.859375,
-          0.859375
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "Normal",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "SE" },
+      "SequenceVariant": { "exactly": [ "SK", "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "regex": "^\\*tse2d1_\\d+$" },
+      "SliceThickness": { "exactly": 6 },
+      "RepetitionTime": { "exactly": 2000 },
+      "EchoTime": { "exactly": 26 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 7.8 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 166 },
+      "EchoTrainLength": { "exactly": 17 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 220 },
+      "AcquisitionMatrix": { "exactly": [ 0, 128, 128, 0 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "ROW" },
+      "FlipAngle": { "exactly": 150 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 256 },
+      "Columns": { "exactly": 256 },
+      "PixelSpacing": { "exactly": [ 0.859375, 0.859375 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "Normal" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       }
     }
   },
   "MP2RAGE": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": [
-          "GR",
-          "IR"
-        ],
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP",
-          "MP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "IR",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^(WIP_|)cmp3d1_\\d+ns$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2600,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 2.82,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 210,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 93.75,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 240,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          0,
-          224,
-          210,
-          0
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "ROW",
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 224,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 210,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.1428571939468,
-          1.1428571939468
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Sag|S>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "Fast",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "comparison": "absent",
-        "compulsory": false
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": ["GR", "IR"] },
+      "SequenceVariant": { "exactly": ["SK", "SP", "MP"] },
+      "ScanOptions": { "exactly": "IR" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^(WIP_|)cmp3d1_\\d+ns$" },
+      "SliceThickness": { "exactly": 5 },
+      "RepetitionTime": { "exactly": 2600 },
+      "EchoTime": { "exactly": 2.82 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 210 },
+      "EchoTrainLength": { "exactly": 1 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 93.75 },
+      "PixelBandwidth": { "exactly": 240 },
+      "AcquisitionMatrix": { "exactly": [ 0, 224, 210, 0 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "ROW" },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 224 },
+      "Columns": { "exactly": 210 },
+      "PixelSpacing": { "in_range": [ [1.14285, 1.14286], [1.14285,1.14286] ] },
+      "PRIVATE-Orientation": { "regex": "^(Sag|S>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "Fast" },
+      "PRIVATE-ParallelImagingAcceleration": { "absent": null }
     },
     "series": {
       "First inversion": {
         "fields": {
-          "ImageType": {
-            "value": [
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "M",
-                "ND",
-                "NORM"
-              ],
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "P",
-                "ND"
-              ]
-            ],
-            "comparison": "in_set"
-          },
-          "FlipAngle": {
-            "value": 5,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 600,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Inv1 Image",
-            "comparison": "exact"
-          }
+          "ImageType": { "in_set": [ ["ORIGINAL", "PRIMARY", "M", "ND", "NORM" ],
+                                     ["ORIGINAL", "PRIMARY", "P", "ND"] ] },
+          "FlipAngle": { "exactly": 5 },
+          "InversionTime": { "exactly": 600 },
+          "ImageComments": { "exactly": "Inv1 Image" }
         }
       },
       "Second inversion": {
         "fields": {
-          "ImageType": {
-            "value": [
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "M",
-                "ND",
-                "NORM"
-              ],
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "P",
-                "ND"
-              ]
-            ],
-            "comparison": "in_set"
-          },
-          "FlipAngle": {
-            "value": 5,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 2000,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Inv2 Image",
-            "comparison": "exact"
-          }
+          "ImageType": { "in_set": [ [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM"],
+                                     [ "ORIGINAL", "PRIMARY", "P", "ND" ] ] },
+          "FlipAngle": { "exactly": 5 },
+          "InversionTime": { "exactly": 2000 },
+          "ImageComments": { "exactly": "Inv2 Image" }
         }
       },
       "T1 map": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "T1 MAP",
-              "ND"
-            ],
-            "comparison": "exact"
-          },
-          "FlipAngle": {
-            "value": 0,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 0,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "T1 Map",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "T1 MAP", "ND" ] },
+          "FlipAngle": { "exactly": 0 },
+          "InversionTime": { "exactly": 0 },
+          "ImageComments": { "exactly": "T1 Map" }
         }
       },
       "First simulated inversion time": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          },
-          "FlipAngle": {
-            "value": 0,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 410,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Simulated T1 Contrast",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND" ] },
+          "FlipAngle": { "exactly": 0 },
+          "InversionTime": { "exactly": 410 },
+          "ImageComments": { "exactly": "Simulated T1 Contrast" }
         }
       },
       "Second simulated inversion time": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          },
-          "FlipAngle": {
-            "value": 0,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 1100,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Simulated T1 Contrast",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND" ] },
+          "FlipAngle": { "exactly": 0 },
+          "InversionTime": { "exactly": 1100 },
+          "ImageComments": { "exactly": "Simulated T1 Contrast" }
         }
       },
       "Uniform intensity image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND",
-              "UNI"
-            ],
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Uniform Image",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND", "UNI" ] },
+          "ImageComments": { "exactly": "Uniform Image" }
         }
       },
       "Denoised uniform intensity image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND",
-              "UNI"
-            ],
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "^Denoised Image \\(lambda = \\d+(\\.\\d+)?\\)$",
-            "comparison": "regex"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND", "UNI" ] },
+          "ImageComments": { "regex": "^Denoised Image \\(lambda = \\d+(\\.\\d+)?\\)$" }
         }
       }
     }
   },
   "T2*-weighted multi-echo gradient echo": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*fl3d\\d+r",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 25,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": [
-          10,
-          15,
-          20
-        ],
-        "comparison": "in_set"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": [
-          1,
-          2,
-          3
-        ],
-        "comparison": "in_set"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 3,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 90.625,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 310,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          58
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 15,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 58,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3.59375,
-          3.59375
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Cor|C>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "Normal",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p3",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^\\*fl3d\\d+r" },
+      "SliceThickness": { "exactly": 5 },
+      "RepetitionTime": { "exactly": 25 },
+      "EchoTime": { "in_set": [10, 15, 20] },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "in_set": [1, 2, 3] },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 3 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 90.625 },
+      "PixelBandwidth": { "exactly": 310 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 58 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 15 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 58 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [3.59375,3.59375] },
+      "PRIVATE-Orientation": { "regex": "^(Cor|C>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "Normal" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p3" }
     },
     "series": {
       "Magnitude (original)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND" ] }
         }
       },
       "Magnitude (normalised)": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       },
       "Phase": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "P",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "P", "ND" ] }
         }
       },
       "R2* map": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "R2_STAR MAP",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "R2_STAR MAP", "ND", "NORM" ] }
         }
       }
     }
   },
   "Spin-echo EPI (product); A>>P": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "^.*(_ap|A>>P)$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 128,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 128,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.5,
-          1.5
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SP" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*ep_b0" },
+      "SeriesDescription": { "regex": "^.*(_ap|A>>P)$" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3000 },
+      "EchoTime": { "exactly": 60 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 128 },
+      "Columns": { "exactly": 128 },
+      "PixelSpacing": { "exactly": [ 1.5, 1.5 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "duplicates_expected": 2,
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
   },
   "Spin-echo EPI (product); P>>A": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "^.*(_pa|P>>A)$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 128,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 128,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.5,
-          1.5
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SP" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*ep_b0" },
+      "SeriesDescription": { "regex": "^.*(_pa|P>>A)$" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3000 },
+      "EchoTime": { "exactly": 60 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 128 },
+      "Columns": { "exactly": 128 },
+      "PixelSpacing": { "exactly": [ 1.5, 1.5 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "duplicates_expected": 2,
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
   },
   "Task-based fMRI BOLD": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SK",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*epfid2d\\d+_\\d+$",
-        "comparison": "regex"
-      },
-      "SeriesDescription": {
-        "value": "(^|[\\W_])(task|Task|TASK)",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2800,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 30,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": "SK" },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "regex": "^\\*epfid2d\\d+_\\d+$" },
+      "SeriesDescription": { "regex": "(^|[\\W_])(task|Task|TASK)" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 2800 },
+      "EchoTime": { "exactly": 30 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [ 3, 3 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "PERFUSION",
-              "NONE",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "PERFUSION", "NONE", "ND" ] }
         }
       }
     }
   },
   "Resting-state fMRI BOLD": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SK",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*epfid2d\\d+_\\d+$",
-        "comparison": "regex"
-      },
-      "SeriesDescription": {
-        "value": "(^|[\\W_])(rest|Rest|REST)",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2800,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 30,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": "SK" },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "regex": "^\\*epfid2d\\d+_\\d+$" },
+      "SeriesDescription": { "regex": "(^|[\\W_])(rest|Rest|REST)" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 2800 },
+      "EchoTime": { "exactly": 30 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [3,3] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "PERFUSION",
-              "NONE",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "PERFUSION", "NONE", "ND" ] }
         }
       }
     }
   },
   "Spin-echo EPI (CMRR); A>>P": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SS"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "^.*(_ap|A>>P)$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SS" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "ep_b0" },
+      "SeriesDescription": { "regex": "^.*(_ap|A>>P)$" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3000 },
+      "EchoTime": { "exactly": 60 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [ 3, 3 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
   },
   "Spin-echo EPI (CMRR); A>>P Inv-RO-PE": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SS"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "[\\W_]?[iI][nN][vV][\\W_]?[rR][oO][\\W_]?[pP][eE]",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SS" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "ep_b0" },
+      "SeriesDescription": { "regex": "[\\W_]?[iI][nN][vV][\\W_]?[rR][oO][\\W_]?[pP][eE]" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3000 },
+      "EchoTime": { "exactly": 60 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [3, 3 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
   },
   "Diffusion MRI": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SS"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": [
-          "PFP",
-          "FS"
-        ],
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3800,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 81,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": [
-          5.199,
-          5.201
-        ],
-        "comparison": "in_range"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 143,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 71,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 1445,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          192,
-          0,
-          0,
-          192
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "ImageComments": {
-        "value": "SENSE1+",
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.1458333730698,
-          1.1458333730698
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SS" ] },
+      "ScanOptions": { "exactly": [ "PFP", "FS" ] },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3800 },
+      "EchoTime": { "exactly": 81 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "in_range": [5.199, 5.201] },
+      "NumberOfPhaseEncodingSteps": { "exactly": 143 },
+      "EchoTrainLength": { "exactly": 71 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 1445 },
+      "AcquisitionMatrix": { "exactly": [ 192, 0, 0, 192 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "ImageComments": { "exactly": "SENSE1+" },
+      "PixelSpacing": { "in_range": [ [1.14583, 1.14584], [1.14583, 1.14584] ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "DWI magnitude": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+(#\\d+|)$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 1152,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 1152,
-            "comparison": "exact"
-          },
-          "PRIVATE-BValue": {
-            "value": [0, 1000],
-            "comparison": "in_set"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM", "MOSAIC" ] },
+          "SequenceName": { "regex": "^ep_b\\d+(#\\d+|)$" },
+          "Rows": { "exactly": 1152 },
+          "Columns": { "exactly": 1152 },
+          "PRIVATE-BValue": { "in_set": [0, 1000] }
         }
       },
       "DWI phase": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+(#\\d+|)$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 1152,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 1152,
-            "comparison": "exact"
-          },
-          "PRIVATE-BValue": {
-            "value": [0, 1000],
-            "comparison": "in_set"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "MOSAIC" ] },
+          "SequenceName": { "regex": "^ep_b\\d+(#\\d+|)$" },
+          "Rows": { "exactly": 1152 },
+          "Columns": { "exactly": 1152 },
+          "PRIVATE-BValue": { "in_set": [0, 1000] }
         }
       },
       "ADC": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "DIFFUSION",
-              "ADC",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+_\\d+$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 192,
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "ADC", "ND", "NORM" ] },
+          "SequenceName": { "regex": "^ep_b\\d+_\\d+$" },
+          "Rows": { "exactly": 192 },
+          "Columns": { "exactly": 192 }
         }
       },
       "Trace-weighted": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "DIFFUSION",
-              "TRACEW",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+t$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "PRIVATE-BValue": {
-            "value": 1000,
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "TRACEW", "ND", "NORM" ] },
+          "SequenceName": { "regex": "^ep_b\\d+t$" },
+          "Rows": { "exactly": 192 },
+          "Columns": { "exactly": 192 },
+          "PRIVATE-BValue": { "exactly": 1000 }
         }
       },
       "Fractional Anisotropy": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "DIFFUSION",
-              "FA",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b0_\\d+$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "SamplesPerPixel": {
-            "value": 1,
-            "comparison": "exact"
-          },
-          "PhotometricInterpretation": {
-            "value": "MONOCHROME2",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "FA", "ND", "NORM" ] },
+          "SequenceName": { "regex": "^ep_b0_\\d+$" },
+          "Rows": { "exactly": 192 },
+          "Columns": { "exactly": 192 },
+          "SamplesPerPixel": { "exactly": 1 },
+          "PhotometricInterpretation": { "exactly": "MONOCHROME2" }
         }
       }
     }
   },
   "Directionally-Encoded Colour FA": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ImageType": {
-        "value": [
-          "DERIVED",
-          "PRIMARY",
-          "DIFFUSION",
-          "FA",
-          "ND",
-          "NORM"
-        ],
-        "comparison": "exact"
-      },
-      "SamplesPerPixel": {
-        "value": 3,
-        "comparison": "exact"
-      },
-      "PhotometricInterpretation": {
-        "value": "RGB",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "FA", "ND", "NORM" ] },
+      "SamplesPerPixel": { "exactly": 3 },
+      "PhotometricInterpretation": { "exactly": "RGB" }
     },
     "series": {
       "Images": {
         "fields": {
-          "Rows": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 192,
-            "comparison": "exact"
-          }
+          "Rows": { "exactly": 192 },
+          "Columns": { "exactly": 192 }
         }
       }
     }
   },
   "Diffusion Tensor": {
     "fields": {
-      "ImageType": {
-        "value": [
-          "DERIVED",
-          "PRIMARY",
-          "DIFFUSION",
-          "TENSOR",
-          "ND",
-          "NORM"
-        ],
-        "comparison": "exact"
-      },
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ImageComments": {
-        "value": "DTI Tensor",
-        "comparison": "exact"
-      }
+      "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "TENSOR", "ND", "NORM" ] },
+      "Modality": { "exactly": "MR" },
+      "ImageComments": { "exactly": "DTI Tensor" }
     },
     "series": {
-      "Data": {
-      }
+      "Data": { }
     }
   },
   "Pulsed Arterial Spin Labelling": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SK",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*tgse3d1_\\d+$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4.5,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 20.26,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 4.5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 62,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 96.875,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          62
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 180,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 512,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 512,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.875,
-          1.875
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "comparison": "absent",
-        "compulsory": false
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": "SK" },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^\\*tgse3d1_\\d+$" },
+      "SliceThickness": { "exactly": 4.5 },
+      "RepetitionTime": { "exactly": 2000 },
+      "EchoTime": { "exactly": 20.26 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 4.5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 62 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 96.875 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 62 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 180 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 512 },
+      "Columns": { "exactly": 512 },
+      "PixelSpacing": { "exactly": [ 1.875, 1.875 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "absent": null }
     },
     "series": {
       "Images": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "ASL",
-              "NONE",
-              "NORM",
-              "DIS2D",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "NumberOfAverages": {
-            "value": 1,
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "ASL", "NONE", "NORM", "DIS2D", "MOSAIC" ] },
+          "NumberOfAverages": { "exactly": 1 }
         }
       },
       "Perfusion-weighted": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "ASL",
-              "NORM",
-              "DIS2D",
-              "SUB",
-              "TTEST",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "NumberOfAverages": {
-            "value": 2,
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "ASL", "NORM", "DIS2D", "SUB", "TTEST", "MOSAIC" ] },
+          "NumberOfAverages": { "exactly": 2 }
         }
       }
     }
   },
   "Spectroscopy": {
     "fields": {
-      "ImageType": {
-        "value": [
-          "ORIGINAL",
-          "PRIMARY"
-        ],
-        "comparison": "exact"
-      },
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": [
-          "csi_slaser",
-          "Spectroscopy"
-        ],
-        "comparison": "in_set"
-      },
-      "ImageComments": {
-        "value": "^_pwc_\\d+$",
-        "comparison": "regex"
-      }
+      "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY" ] },
+      "Modality": { "exactly": "MR" },
+      "ProtocolName": { "in_set": [ "csi_slaser", "Spectroscopy" ] },
+      "ImageComments": { "regex": "^_pwc_\\d+$" }
     },
     "series": {
-      "Data": {
-      }
+      "Data": { }
     }
   },
   "Phoenix Report": {
     "fields": {
-      "ImageType": {
-        "value": [
-          "ORIGINAL",
-          "PRIMARY",
-          "OTHER",
-          "CSA REPORT"
-        ],
-        "comparison": "exact"
-      },
-      "Modality": {
-        "value": "SR",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": "Phoenix Document",
-        "comparison": "exact"
-      }
+      "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "OTHER", "CSA REPORT" ] },
+      "Modality": { "exactly": "SR" },
+      "ProtocolName": { "exactly": "Phoenix Document" }
     },
     "series": {
-      "Data": {
-      }
+      "Data": { }
     }
   }
 }
+

--- a/docs/tutorial/templates/04_additional.json
+++ b/docs/tutorial/templates/04_additional.json
@@ -2,1001 +2,295 @@
   "GENERAL": {
     "check_ordering": true,
     "fields": {
-      "BodyPartExamined": {
-        "value": "BRAIN",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "AngioFlag": {
-        "value": "N",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "ImagedNucleus": {
-        "value": "1H",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "MagneticFieldStrength": {
-        "value": 3,
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "TransmitCoilName": {
-        "value": "Body",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "dBdt": {
-        "value": 0,
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "PatientPosition": {
-        "value": "HFS",
-        "comparison": "exact",
-        "compulsory": false
-      },
-      "PRIVATE-CoilElementsUsed": {
-        "value": "HE1-4",
-        "comparison": "exact",
-        "compulsory": false
-      }
+      "BodyPartExamined": { "exactly_if_present": "BRAIN" },
+      "AngioFlag": { "exactly_if_present": "N" },
+      "ImagedNucleus": { "exactly_if_present": "1H" },
+      "MagneticFieldStrength": { "exactly_if_present": 3 },
+      "TransmitCoilName": { "exactly_if_present": "Body" },
+      "dBdt": { "exactly_if_present": 0 },
+      "PatientPosition": { "exactly_if_present": "HFS" },
+      "PRIVATE-CoilElementsUsed": { "exactly_if_present": "HE1-4" }
     }
   },
   "Localizer": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*fl2d1",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": "^[lL]ocali[sz]er",
-        "comparison": "regex"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*fl2d1" },
+      "ProtocolName": { "regex": "^[lL]ocali[sz]er" }
     },
     "series": {
       "Image": {
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       }
     }
   },
   "Dual echo gradient echo field map": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SP",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*fm2d2r",
-        "comparison": "exact"
-      },
-      "SliceThickness": {
-        "value": 6,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 200,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 7.38,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 2,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 7.5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 0,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 290,
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "ROW",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "Fast",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "comparison": "absent",
-        "compulsory": false
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": "SP" },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*fm2d2r" },
+      "SliceThickness": { "exactly": 6 },
+      "RepetitionTime": { "exactly": 200 },
+      "EchoTime": { "exactly": 7.38 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 2 },
+      "SpacingBetweenSlices": { "exactly": 7.5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 64 },
+      "EchoTrainLength": { "exactly": 0 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 290 },
+      "InPlanePhaseEncodingDirection": { "exactly": "ROW" },
+      "FlipAngle": { "exactly": 60 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [ 3, 3 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "Fast" },
+      "PRIVATE-ParallelImagingAcceleration": { "absent": null }
     },
     "series": {
       "PhaseDiff": {
         "num_files": 18,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "P",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "P", "ND" ] }
         }
       }
     }
   },
   "T1-weighted FLASH": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*fl2d1",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": "^(?![lL]ocali[sz]er)",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 6,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 2.46,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 7.8,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 167,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 80,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 320,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          0,
-          160,
-          128,
-          0
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "ROW",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 70,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 160,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 160,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.375,
-          1.375
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Sag|S>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "comparison": "absent",
-        "compulsory": false
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*fl2d1" },
+      "ProtocolName": { "regex": "^(?![lL]ocali[sz]er)" },
+      "SliceThickness": { "exactly": 6 },
+      "RepetitionTime": { "exactly": 100 },
+      "EchoTime": { "exactly": 2.46 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 7.8 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 167 },
+      "EchoTrainLength": { "exactly": 1 },
+      "PercentSampling": { "exactly": 80 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 320 },
+      "AcquisitionMatrix": { "exactly": [ 0, 160, 128, 0 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "ROW" },
+      "FlipAngle": { "exactly": 70 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 160 },
+      "Columns": { "exactly": 160 },
+      "PixelSpacing": { "exactly": [ 1.375, 1.375 ] },
+      "PRIVATE-Orientation": { "regex": "^(Sag|S>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "absent": null }
     },
     "series": {
       "Image": {
         "num_files": 12,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       }
     }
   },
   "T2-weighted Turbo Spin Echo": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "SE",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*tse2d1_\\d+$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 6,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 26,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 7.8,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 166,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 17,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 220,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          0,
-          128,
-          128,
-          0
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "ROW",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 150,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 256,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 256,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          0.859375,
-          0.859375
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "Normal",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "SE" },
+      "SequenceVariant": { "exactly": [ "SK", "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "regex": "^\\*tse2d1_\\d+$" },
+      "SliceThickness": { "exactly": 6 },
+      "RepetitionTime": { "exactly": 2000 },
+      "EchoTime": { "exactly": 26 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 7.8 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 166 },
+      "EchoTrainLength": { "exactly": 17 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 220 },
+      "AcquisitionMatrix": { "exactly": [ 0, 128, 128, 0 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "ROW" },
+      "FlipAngle": { "exactly": 150 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 256 },
+      "Columns": { "exactly": 256 },
+      "PixelSpacing": { "exactly": [ 0.859375, 0.859375 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "Normal" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "num_files": 12,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       }
     }
   },
   "MP2RAGE": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": [
-          "GR",
-          "IR"
-        ],
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP",
-          "MP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "IR",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^(WIP_|)cmp3d1_\\d+ns$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2600,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 2.82,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 210,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 93.75,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 240,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          0,
-          224,
-          210,
-          0
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "ROW",
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 224,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 210,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.1428571939468,
-          1.1428571939468
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Sag|S>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "Fast",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "comparison": "absent",
-        "compulsory": false
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": [ "GR", "IR" ] },
+      "SequenceVariant": { "exactly": [ "SK", "SP", "MP" ] },
+      "ScanOptions": { "exactly": "IR" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^(WIP_|)cmp3d1_\\d+ns$" },
+      "SliceThickness": { "exactly": 5 },
+      "RepetitionTime": { "exactly": 2600 },
+      "EchoTime": { "exactly": 2.82 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 210 },
+      "EchoTrainLength": { "exactly": 1 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 93.75 },
+      "PixelBandwidth": { "exactly": 240 },
+      "AcquisitionMatrix": { "exactly": [ 0, 224, 210, 0 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "ROW" },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 224 },
+      "Columns": { "exactly": 210 },
+      "PixelSpacing": { "in_range": [ [ 1.14285, 1.14286], [1.14285, 1.14286] ] },
+      "PRIVATE-Orientation": { "regex": "^(Sag|S>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "Fast" },
+      "PRIVATE-ParallelImagingAcceleration": { "absent": null }
     },
     "series": {
       "First inversion": {
         "num_files": 80,
         "fields": {
-          "ImageType": {
-            "value": [
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "M",
-                "ND",
-                "NORM"
-              ],
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "P",
-                "ND"
-              ]
-            ],
-            "comparison": "in_set"
-          },
-          "FlipAngle": {
-            "value": 5,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 600,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Inv1 Image",
-            "comparison": "exact"
-          }
+          "ImageType": { "in_set": [ [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ],
+                                     [ "ORIGINAL", "PRIMARY", "P", "ND" ] ] },
+          "FlipAngle": { "exactly": 5 },
+          "InversionTime": { "exactly": 600 },
+          "ImageComments": { "exactly": "Inv1 Image" }
         }
       },
       "Second inversion": {
         "num_files": 79,
         "fields": {
-          "ImageType": {
-            "value": [
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "M",
-                "ND",
-                "NORM"
-              ],
-              [
-                "ORIGINAL",
-                "PRIMARY",
-                "P",
-                "ND"
-              ]
-            ],
-            "comparison": "in_set"
-          },
-          "FlipAngle": {
-            "value": 5,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 2000,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Inv2 Image",
-            "comparison": "exact"
-          }
+          "ImageType": { "in_set": [ [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ],
+                                     [ "ORIGINAL", "PRIMARY", "P", "ND" ] ] },
+          "FlipAngle": { "exactly": 5 },
+          "InversionTime": { "exactly": 2000 },
+          "ImageComments": { "exactly": "Inv2 Image" }
         }
       },
       "T1 map": {
         "num_files": 39,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "T1 MAP",
-              "ND"
-            ],
-            "comparison": "exact"
-          },
-          "FlipAngle": {
-            "value": 0,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 0,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "T1 Map",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "T1 MAP", "ND" ] },
+          "FlipAngle": { "exactly": 0 },
+          "InversionTime": { "exactly": 0 },
+          "ImageComments": { "exactly": "T1 Map" }
         }
       },
       "First simulated inversion time": {
         "num_files": 39,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          },
-          "FlipAngle": {
-            "value": 0,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 410,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Simulated T1 Contrast",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND" ] },
+          "FlipAngle": { "exactly": 0 },
+          "InversionTime": { "exactly": 410 },
+          "ImageComments": { "exactly": "Simulated T1 Contrast" }
         }
       },
       "Second simulated inversion time": {
        "num_files": 39,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          },
-          "FlipAngle": {
-            "value": 0,
-            "comparison": "exact"
-          },
-          "InversionTime": {
-            "value": 1100,
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Simulated T1 Contrast",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND" ] },
+          "FlipAngle": { "exactly": 0 },
+          "InversionTime": { "exactly": 1100 },
+          "ImageComments": { "exactly": "Simulated T1 Contrast" }
         }
       },
       "Uniform intensity image": {
         "num_files": 39,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND",
-              "UNI"
-            ],
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "Uniform Image",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND", "UNI" ] },
+          "ImageComments": { "exactly": "Uniform Image" }
         }
       },
       "Denoised uniform intensity image": {
         "num_files": 39,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "M",
-              "ND",
-              "UNI"
-            ],
-            "comparison": "exact"
-          },
-          "ImageComments": {
-            "value": "^Denoised Image \\(lambda = \\d+(\\.\\d+)?\\)$",
-            "comparison": "regex"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "M", "ND", "UNI" ] },
+          "ImageComments": { "regex": "^Denoised Image \\(lambda = \\d+(\\.\\d+)?\\)$" }
         }
       }
     }
   },
   "T2*-weighted multi-echo gradient echo": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "GR",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SP",
-          "OSP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*fl3d\\d+r",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 25,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": [
-          10,
-          15,
-          20
-        ],
-        "comparison": "in_set"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": [
-          1,
-          2,
-          3
-        ],
-        "comparison": "in_set"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 3,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 90.625,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 310,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          58
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 15,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 58,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3.59375,
-          3.59375
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Cor|C>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "Normal",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p3",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "GR" },
+      "SequenceVariant": { "exactly": [ "SP", "OSP" ] },
+      "ScanOptions": { "exactly": "" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^\\*fl3d\\d+r" },
+      "SliceThickness": { "exactly": 5 },
+      "RepetitionTime": { "exactly": 25 },
+      "EchoTime": { "in_set": [10, 15, 20] },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "in_set": [1, 2, 3] },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 3 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 90.625 },
+      "PixelBandwidth": { "exactly": 310 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 58 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 15 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 58 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [3.59375, 3.59375] },
+      "PRIVATE-Orientation": { "regex": "^(Cor|C>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "Normal" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p3" }
     },
     "series": {
       "Magnitude (original)": {
         "num_files": 90,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND" ] }
         }
       },
       "Magnitude (normalised)": {
         "num_files": 90,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "M",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "M", "ND", "NORM" ] }
         }
       },
       "Phase": {
         "num_files": 90,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "P",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "P", "ND" ] }
         }
       },
       "R2* map": {
         "num_files": 30,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "R2_STAR MAP",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "R2_STAR MAP", "ND", "NORM" ] }
         }
       }
     }
@@ -1004,146 +298,41 @@
   "Spin-echo EPI (product); A>>P": {
     "ignore_ordering": true,
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "^.*(_ap|A>>P)$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 128,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 128,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.5,
-          1.5
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SP" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*ep_b0" },
+      "SeriesDescription": { "regex": "^.*(_ap|A>>P)$" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3000 },
+      "EchoTime": { "exactly": 60 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 128 },
+      "Columns": { "exactly": 128 },
+      "PixelSpacing": { "exactly": [ 1.5, 1.5 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "duplicates_expected": 2,
     "series": {
       "Image": {
         "num_files": 25,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
@@ -1151,146 +340,41 @@
   "Spin-echo EPI (product); P>>A": {
     "ignore_ordering": true,
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SP"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "*ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "^.*(_pa|P>>A)$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 128,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 128,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.5,
-          1.5
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SP" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "*ep_b0" },
+      "SeriesDescription": { "regex": "^.*(_pa|P>>A)$" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3000 },
+      "EchoTime": { "exactly": 60 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 128 },
+      "Columns": { "exactly": 128 },
+      "PixelSpacing": { "exactly": [ 1.5, 1.5 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "duplicates_expected": 2,
     "series": {
       "Image": {
         "num_files": 25,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
@@ -1304,141 +388,40 @@
       "position": "before"
     },
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SK",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*epfid2d\\d+_\\d+$",
-        "comparison": "regex"
-      },
-      "SeriesDescription": {
-        "value": "(^|[\\W_])(task|Task|TASK)$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2800,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 30,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": "SK" },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "regex": "^\\*epfid2d\\d+_\\d+$" },
+      "SeriesDescription": { "regex": "(^|[\\W_])(task|Task|TASK)$" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 2800 },
+      "EchoTime": { "exactly": 30 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [3, 3] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "num_files": 100,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "PERFUSION",
-              "NONE",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "PERFUSION", "NONE", "ND" ] }
         }
       }
     }
@@ -1452,141 +435,40 @@
       "position": "before"
     },
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SK",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*epfid2d\\d+_\\d+$",
-        "comparison": "regex"
-      },
-      "SeriesDescription": {
-        "value": "(^|[\\W_])(rest|Rest|REST)",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2800,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 30,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": "SK" },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "regex": "^\\*epfid2d\\d+_\\d+$" },
+      "SeriesDescription": { "regex": "(^|[\\W_])(rest|Rest|REST)" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 2800 },
+      "EchoTime": { "exactly": 30 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [ 3, 3 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "num_files": 200,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "PERFUSION",
-              "NONE",
-              "ND"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "PERFUSION", "NONE", "ND" ] }
         }
       }
     }
@@ -1594,145 +476,40 @@
   "Spin-echo EPI (CMRR); A>>P": {
     "ignore_ordering": true,
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SS"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "^.*(_ap|A>>P)$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SS" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "ep_b0" },
+      "SeriesDescription": { "regex": "^.*(_ap|A>>P)$" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3000 },
+      "EchoTime": { "exactly": 60 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [3, 3] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "num_files": 25,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
@@ -1740,145 +517,40 @@
   "Spin-echo EPI (CMRR); A>>P Inv-RO-PE": {
     "ignore_ordering": true,
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SS"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "ep_b0",
-        "comparison": "exact"
-      },
-      "SeriesDescription": {
-        "value": "[\\W_]?[iI][nN][vV][\\W_]?[rR][oO][\\W_]?[pP][eE]",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 60,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 63,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          64
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 64,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          3,
-          3
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SS" ] },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SequenceName": { "exactly": "ep_b0" },
+      "SeriesDescription": { "regex": "[\\W_]?[iI][nN][vV][\\W_]?[rR][oO][\\W_]?[pP][eE]" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3000 },
+      "EchoTime": { "exactly": 60 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 63 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 64 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 64 },
+      "Columns": { "exactly": 64 },
+      "PixelSpacing": { "exactly": [3, 3 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "Image": {
         "num_files": 25,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM" ] }
         }
       }
     }
@@ -1892,351 +564,107 @@
       "position": "before"
     },
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": [
-          "SK",
-          "SS"
-        ],
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": [
-          "PFP",
-          "FS"
-        ],
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "2D",
-        "comparison": "exact"
-      },
-      "SliceThickness": {
-        "value": 4,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 3800,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 81,
-        "comparison": "exact"
-      },
-      "NumberOfAverages": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": [
-          5.199,
-          5.201
-        ],
-        "comparison": "in_range"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 143,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 71,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 1445,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          192,
-          0,
-          0,
-          192
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 90,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "ImageComments": {
-        "value": "SENSE1+",
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.1458333730698,
-          1.1458333730698
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "value": "p2",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": [ "SK", "SS" ] },
+      "ScanOptions": { "exactly": [ "PFP", "FS" ] },
+      "MRAcquisitionType": { "exactly": "2D" },
+      "SliceThickness": { "exactly": 4 },
+      "RepetitionTime": { "exactly": 3800 },
+      "EchoTime": { "exactly": 81 },
+      "NumberOfAverages": { "exactly": 1 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "in_range": [5.199, 5.201] },
+      "NumberOfPhaseEncodingSteps": { "exactly": 143 },
+      "EchoTrainLength": { "exactly": 71 },
+      "PercentSampling": { "exactly": 100 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 1445 },
+      "AcquisitionMatrix": { "exactly": [ 192, 0, 0, 192 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 90 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "ImageComments": { "exactly": "SENSE1+" },
+      "PixelSpacing": { "in_range": [ [1.14583, 1.14584], [1.14583, 1.14584] ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "exactly": "p2" }
     },
     "series": {
       "DWI magnitude": {
         "num_files": 7,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "NORM",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+(#\\d+|)$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 1152,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 1152,
-            "comparison": "exact"
-          },
-          "PRIVATE-BValue": {
-            "value": [0, 5, 10, 15, 985, 990, 995, 1000, 1005, 1010, 1015],
-            "comparison": "in_set"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "NORM", "MOSAIC" ] },
+          "SequenceName": { "regex": "^ep_b\\d+(#\\d+|)$" },
+          "Rows": { "exactly": 1152 },
+          "Columns": { "exactly": 1152 },
+          "PRIVATE-BValue": { "in_set": [0, 5, 10, 15, 985, 990, 995, 1000, 1005, 1010, 1015] }
         }
       },
       "DWI phase": {
         "num_files": 7,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "DIFFUSION",
-              "NONE",
-              "ND",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+(#\\d+|)$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 1152,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 1152,
-            "comparison": "exact"
-          },
-          "PRIVATE-BValue": {
-            "value": [0, 5, 10, 15, 985, 990, 995, 1000, 1005, 1010, 1015],
-            "comparison": "in_set"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "DIFFUSION", "NONE", "ND", "MOSAIC" ] },
+          "SequenceName": { "regex": "^ep_b\\d+(#\\d+|)$" },
+          "Rows": { "exactly": 1152 },
+          "Columns": { "exactly": 1152 },
+          "PRIVATE-BValue": { "in_set": [0, 5, 10, 15, 985, 990, 995, 1000, 1005, 1010, 1015] }
         }
       },
       "ADC": {
         "num_files": 27,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "DIFFUSION",
-              "ADC",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+_\\d+$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 192,
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "ADC", "ND", "NORM" ] },
+          "SequenceName": { "regex": "^ep_b\\d+_\\d+$" },
+          "Rows": { "exactly": 192 },
+          "Columns": { "exactly": 192 }
         }
       },
       "Trace-weighted": {
         "num_files": 27,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "DIFFUSION",
-              "TRACEW",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+t$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "PRIVATE-BValue": {
-            "value": [985, 990, 995, 1000, 1005, 1010, 1015],
-            "comparison": "in_set"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "TRACEW", "ND", "NORM" ] },
+          "SequenceName": { "regex": "^ep_b\\d+t$" },
+          "Rows": { "exactly": 192 },
+          "Columns": { "exactly": 192 },
+          "PRIVATE-BValue": { "in_set": [985, 990, 995, 1000, 1005, 1010, 1015] }
         }
       },
       "Fractional Anisotropy": {
         "num_files": 27,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "DIFFUSION",
-              "FA",
-              "ND",
-              "NORM"
-            ],
-            "comparison": "exact"
-          },
-          "SequenceName": {
-            "value": "^ep_b\\d+_\\d+$",
-            "comparison": "regex"
-          },
-          "Rows": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "SamplesPerPixel": {
-            "value": 1,
-            "comparison": "exact"
-          },
-          "PhotometricInterpretation": {
-            "value": "MONOCHROME2",
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "FA", "ND", "NORM" ] },
+          "SequenceName": { "regex": "^ep_b\\d+_\\d+$" },
+          "Rows": { "exactly": 192 },
+          "Columns": { "exactly": 192 },
+          "SamplesPerPixel": { "exactly": 1 },
+          "PhotometricInterpretation": { "exactly": "MONOCHROME2" }
         }
       }
     }
   },
   "Directionally-Encoded Colour FA": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ImageType": {
-        "value": [
-          "DERIVED",
-          "PRIMARY",
-          "DIFFUSION",
-          "FA",
-          "ND",
-          "NORM"
-        ],
-        "comparison": "exact"
-      },
-      "SamplesPerPixel": {
-        "value": 3,
-        "comparison": "exact"
-      },
-      "PhotometricInterpretation": {
-        "value": "RGB",
-        "comparison": "exact"
-      }
+      "Modality": { "exactly": "MR" },
+      "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "FA", "ND", "NORM" ] },
+      "SamplesPerPixel": { "exactly": 3 },
+      "PhotometricInterpretation": { "exactly": "RGB" }
     },
     "series": {
       "Images": {
         "num_files": 27,
         "fields": {
-          "Rows": {
-            "value": 192,
-            "comparison": "exact"
-          },
-          "Columns": {
-            "value": 192,
-            "comparison": "exact"
-          }
+          "Rows": { "exactly": 192 },
+          "Columns": { "exactly": 192 }
         }
       }
     }
   },
   "Diffusion Tensor": {
     "fields": {
-      "ImageType": {
-        "value": [
-          "DERIVED",
-          "PRIMARY",
-          "DIFFUSION",
-          "TENSOR",
-          "ND",
-          "NORM"
-        ],
-        "comparison": "exact"
-      },
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ImageComments": {
-        "value": "DTI Tensor",
-        "comparison": "exact"
-      }
+      "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "DIFFUSION", "TENSOR", "ND", "NORM" ] },
+      "Modality": { "exactly": "MR" },
+      "ImageComments": { "exactly": "DTI Tensor" }
     },
     "series": {
       "Data": {
@@ -2246,189 +674,56 @@
   },
   "Pulsed Arterial Spin Labelling": {
     "fields": {
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ScanningSequence": {
-        "value": "EP",
-        "comparison": "exact"
-      },
-      "SequenceVariant": {
-        "value": "SK",
-        "comparison": "exact"
-      },
-      "ScanOptions": {
-        "value": "FS",
-        "comparison": "exact"
-      },
-      "MRAcquisitionType": {
-        "value": "3D",
-        "comparison": "exact"
-      },
-      "SequenceName": {
-        "value": "^\\*tgse3d1_\\d+$",
-        "comparison": "regex"
-      },
-      "SliceThickness": {
-        "value": 4.5,
-        "comparison": "exact"
-      },
-      "RepetitionTime": {
-        "value": 2000,
-        "comparison": "exact"
-      },
-      "EchoTime": {
-        "value": 20.26,
-        "comparison": "exact"
-      },
-      "EchoNumbers": {
-        "value": 1,
-        "comparison": "exact"
-      },
-      "SpacingBetweenSlices": {
-        "value": 4.5,
-        "comparison": "exact"
-      },
-      "NumberOfPhaseEncodingSteps": {
-        "value": 62,
-        "comparison": "exact"
-      },
-      "EchoTrainLength": {
-        "value": 31,
-        "comparison": "exact"
-      },
-      "PercentSampling": {
-        "value": 96.875,
-        "comparison": "exact"
-      },
-      "PercentPhaseFieldOfView": {
-        "value": 100,
-        "comparison": "exact"
-      },
-      "PixelBandwidth": {
-        "value": 2440,
-        "comparison": "exact"
-      },
-      "AcquisitionMatrix": {
-        "value": [
-          64,
-          0,
-          0,
-          62
-        ],
-        "comparison": "exact"
-      },
-      "InPlanePhaseEncodingDirection": {
-        "value": "COL",
-        "comparison": "exact"
-      },
-      "FlipAngle": {
-        "value": 180,
-        "comparison": "exact"
-      },
-      "VariableFlipAngleFlag": {
-        "value": "N",
-        "comparison": "exact"
-      },
-      "Rows": {
-        "value": 512,
-        "comparison": "exact"
-      },
-      "Columns": {
-        "value": 512,
-        "comparison": "exact"
-      },
-      "PixelSpacing": {
-        "value": [
-          1.875,
-          1.875
-        ],
-        "comparison": "exact"
-      },
-      "PRIVATE-Orientation": {
-        "value": "^(Tra|T>.*)$",
-        "comparison": "regex"
-      },
-      "PRIVATE-GradientMode": {
-        "value": "",
-        "comparison": "exact"
-      },
-      "PRIVATE-ParallelImagingAcceleration": {
-        "comparison": "absent",
-        "compulsory": false
-      }
+      "Modality": { "exactly": "MR" },
+      "ScanningSequence": { "exactly": "EP" },
+      "SequenceVariant": { "exactly": "SK" },
+      "ScanOptions": { "exactly": "FS" },
+      "MRAcquisitionType": { "exactly": "3D" },
+      "SequenceName": { "regex": "^\\*tgse3d1_\\d+$" },
+      "SliceThickness": { "exactly": 4.5 },
+      "RepetitionTime": { "exactly": 2000 },
+      "EchoTime": { "exactly": 20.26 },
+      "EchoNumbers": { "exactly": 1 },
+      "SpacingBetweenSlices": { "exactly": 4.5 },
+      "NumberOfPhaseEncodingSteps": { "exactly": 62 },
+      "EchoTrainLength": { "exactly": 31 },
+      "PercentSampling": { "exactly": 96.875 },
+      "PercentPhaseFieldOfView": { "exactly": 100 },
+      "PixelBandwidth": { "exactly": 2440 },
+      "AcquisitionMatrix": { "exactly": [ 64, 0, 0, 62 ] },
+      "InPlanePhaseEncodingDirection": { "exactly": "COL" },
+      "FlipAngle": { "exactly": 180 },
+      "VariableFlipAngleFlag": { "exactly": "N" },
+      "Rows": { "exactly": 512 },
+      "Columns": { "exactly": 512 },
+      "PixelSpacing": { "exactly": [ 1.875, 1.875 ] },
+      "PRIVATE-Orientation": { "regex": "^(Tra|T>.*)$" },
+      "PRIVATE-GradientMode": { "exactly": "" },
+      "PRIVATE-ParallelImagingAcceleration": { "absent": null }
     },
     "series": {
       "Images": {
         "num_files": 4,
         "fields": {
-          "ImageType": {
-            "value": [
-              "ORIGINAL",
-              "PRIMARY",
-              "ASL",
-              "NONE",
-              "NORM",
-              "DIS2D",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "NumberOfAverages": {
-            "value": 1,
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "ASL", "NONE", "NORM", "DIS2D", "MOSAIC" ] },
+          "NumberOfAverages": { "exactly": 1 }
         }
       },
       "Perfusion-weighted": {
         "num_files": 1,
         "fields": {
-          "ImageType": {
-            "value": [
-              "DERIVED",
-              "PRIMARY",
-              "ASL",
-              "NORM",
-              "DIS2D",
-              "SUB",
-              "TTEST",
-              "MOSAIC"
-            ],
-            "comparison": "exact"
-          },
-          "NumberOfAverages": {
-            "value": 2,
-            "comparison": "exact"
-          }
+          "ImageType": { "exactly": [ "DERIVED", "PRIMARY", "ASL", "NORM", "DIS2D", "SUB", "TTEST", "MOSAIC" ] },
+          "NumberOfAverages": { "exactly": 2 }
         }
       }
     }
   },
   "Spectroscopy": {
     "fields": {
-      "ImageType": {
-        "value": [
-          "ORIGINAL",
-          "PRIMARY"
-        ],
-        "comparison": "exact"
-      },
-      "Modality": {
-        "value": "MR",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": [
-          "csi_slaser",
-          "Spectroscopy"
-        ],
-        "comparison": "in_set"
-      },
-      "ImageComments": {
-        "value": "^_pwc_\\d+$",
-        "comparison": "regex"
-      }
+      "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY" ] },
+      "Modality": { "exactly": "MR" },
+      "ProtocolName": { "in_set": [ "csi_slaser", "Spectroscopy" ] },
+      "ImageComments": { "regex": "^_pwc_\\d+$" }
     },
     "series": {
       "Data": {
@@ -2438,27 +733,13 @@
   },
   "Phoenix Report": {
     "fields": {
-      "ImageType": {
-        "value": [
-          "ORIGINAL",
-          "PRIMARY",
-          "OTHER",
-          "CSA REPORT"
-        ],
-        "comparison": "exact"
-      },
-      "Modality": {
-        "value": "SR",
-        "comparison": "exact"
-      },
-      "ProtocolName": {
-        "value": "Phoenix Document",
-        "comparison": "exact"
-      }
+      "ImageType": { "exactly": [ "ORIGINAL", "PRIMARY", "OTHER", "CSA REPORT" ] },
+      "Modality": { "exactly": "SR" },
+      "ProtocolName": { "exactly": "Phoenix Document" }
     },
     "series": {
-      "Data": {
-      }
+      "Data": { }
     }
   }
 }
+

--- a/src/protocol_qc/classes/series.py
+++ b/src/protocol_qc/classes/series.py
@@ -392,7 +392,7 @@ class TemplateSeries:
                     f" Series \"{self.name}\";"
                     f" field \"{field_name}\""
                     " does not have exactly one entry"
-                ) from exc
+                )
             comparison_name, reference = next(iter(details.items()))
             try:
                 comparison = getattr(Comparison, comparison_name)

--- a/src/protocol_qc/convert_template.py
+++ b/src/protocol_qc/convert_template.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# protocol_qc: An MRI DICOM protocol quality control tool
+# Copyright (C) 2025 The Florey Institute of Neuroscience and Mental Health
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+Convert protocol_qc template JSON files from the pre-PR#42 format to the
+format expected by the updated field-comparison parser.
+
+Old format:
+    "FieldName": {
+        "value": <value>,
+        "comparison": "<comparison_type>",
+        ["compulsory": <bool>]
+    }
+
+New format:
+    "FieldName": { "<comparison_type>": <value> }
+
+Mapping of old comparison types to new:
+    "exact"    (compulsory unset or true)  -> "exactly"
+    "exact"    (compulsory: false)         -> "exactly_if_present"
+    "regex"                                -> "regex"
+    "absent"                               -> "absent"  (value: null)
+    "in_set"                               -> "in_set"
+    "in_range"                             -> "in_range"
+
+The "options"-style entries inside "tags" blocks (where each option has a
+"field" key and "comparison"/"value" keys) are also converted to the new
+single-key format, consistent with how generate_tags.py now reads them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+_COMPARISON_RENAME: dict[str, str] = {
+    "exact": "exactly",
+    "regex": "regex",
+    "absent": "absent",
+    "in_set": "in_set",
+    "in_range": "in_range",
+}
+
+# Tag option entries do not support "absent" or "compulsory".
+_TAG_COMPARISON_RENAME: dict[str, str] = {
+    "exact": "exactly",
+    "regex": "regex",
+    "in_set": "in_set",
+    "in_range": "in_range",
+}
+
+
+def _convert_field_spec(field_name: str, spec: Any) -> Any:
+    """
+    Convert one entry from a ``fields`` dict.
+
+    If ``spec`` is already in the new single-key format (no ``"comparison"``
+    key present), it is returned unchanged.
+
+    Parameters
+    ----------
+    field_name
+        Name of the DICOM header field (used only for error messages).
+    spec
+        Value associated with ``field_name`` in a ``"fields"`` block.
+
+    Returns
+    -------
+        Converted field specification.
+
+    Raises
+    ------
+    KeyError
+        If the old ``"comparison"`` value is not a recognised type.
+    """
+    if not isinstance(spec, dict) or "comparison" not in spec:
+        return spec
+
+    comparison: str = spec["comparison"]
+    compulsory: bool = spec.get("compulsory", True)
+    value: Any = spec.get("value", None)
+
+    if comparison == "absent":
+        return {"absent": None}
+
+    if comparison not in _COMPARISON_RENAME:
+        raise KeyError(
+            f"Field \"{field_name}\": unrecognised comparison type \"{comparison}\""
+        )
+
+    new_key: str = _COMPARISON_RENAME[comparison]
+
+    if comparison == "exact" and compulsory is False:
+        new_key = "exactly_if_present"
+
+    return {new_key: value}
+
+
+def _convert_fields_block(fields: dict[str, Any]) -> dict[str, Any]:
+    """
+    Convert every entry in a ``"fields"`` block from old to new format.
+
+    Parameters
+    ----------
+    fields
+        The dict that is the value of a ``"fields"`` key.
+
+    Returns
+    -------
+        Converted fields block.
+    """
+    return {name: _convert_field_spec(name, spec) for name, spec in fields.items()}
+
+
+def _convert_tag_option(option_label: str, spec: Any) -> Any:
+    """
+    Convert one option entry inside an ``"options"``-style ``"tag"`` dict.
+
+    If *spec* is already in the new single-key format (no ``"comparison"``
+    key present), it is returned unchanged.
+
+    Old format::
+
+        {"field": "FieldName", "value": X, "comparison": "type"}
+
+    New format::
+
+        {"field": "FieldName", "type": X}
+
+    Parameters
+    ----------
+    option_label
+        The label for this option (used only in error messages).
+    spec
+        The dict describing one tag option.
+
+    Returns
+    -------
+        Converted option dict.
+
+    Raises
+    ------
+    KeyError
+        If the ``"comparison"`` value is not a recognised type, or if
+        ``"field"`` is missing.
+    """
+    if not isinstance(spec, dict) or "comparison" not in spec:
+        return spec
+
+    field: str = spec["field"]
+    comparison: str = spec["comparison"]
+    value: Any = spec.get("value", None)
+
+    if comparison not in _TAG_COMPARISON_RENAME:
+        raise KeyError(
+            f"Tag option \"{option_label}\":"
+            f" unrecognised comparison type \"{comparison}\""
+        )
+
+    return {"field": field, _TAG_COMPARISON_RENAME[comparison]: value}
+
+
+def _convert_tags_block(tags: dict[str, Any]) -> dict[str, Any]:
+    """
+    Convert all ``"options"``-style tag entries within a ``"tags"`` block.
+
+    Only entries whose ``"tag"`` value is a dict (the ``"options"`` pattern)
+    contain field comparisons that need converting.  ``"constant"`` and
+    ``"fill_with"`` entries are left unchanged.
+
+    Parameters
+    ----------
+    tags
+        The dict that is the value of a ``"tags"`` key.
+
+    Returns
+    -------
+        Converted tags block.
+    """
+    result: dict[str, Any] = {}
+    for tag_name, tag_spec in tags.items():
+        if isinstance(tag_spec, dict) and isinstance(tag_spec.get("tag"), dict):
+            new_options = {
+                label: _convert_tag_option(label, opt)
+                for label, opt in tag_spec["tag"].items()
+            }
+            result[tag_name] = {**tag_spec, "tag": new_options}
+        else:
+            result[tag_name] = tag_spec
+    return result
+
+
+def _convert_node(node: Any) -> Any:
+    """
+    Recursively convert all ``"fields"`` and ``"tags"`` blocks found in *node*.
+
+    Parameters
+    ----------
+    node
+        Any JSON-decoded Python object.
+
+    Returns
+    -------
+        A new object with all ``"fields"`` and ``"tags"`` blocks converted.
+    """
+    if not isinstance(node, dict):
+        return node
+
+    result: dict[str, Any] = {}
+    for key, value in node.items():
+        if key == "tags" and isinstance(value, dict):
+            result[key] = _convert_tags_block(value)
+        elif key == "fields" and isinstance(value, dict):
+            result[key] = _convert_fields_block(value)
+        elif isinstance(value, dict):
+            result[key] = _convert_node(value)
+        elif isinstance(value, list):
+            result[key] = [_convert_node(item) for item in value]
+        else:
+            result[key] = value
+
+    return result
+
+
+def convert_template(template: dict[str, Any]) -> dict[str, Any]:
+    """
+    Convert a loaded protocol template from the old field-specification
+    format to the new one.
+
+    Parameters
+    ----------
+    template
+        Python dict produced by ``json.load`` of a template file.
+
+    Returns
+    -------
+        Converted template dict.
+    """
+    return _convert_node(template)
+
+
+def _process_file(
+    input_path: Path,
+    output_path: Path | None,
+    in_place: bool,
+) -> None:
+    """
+    Load, convert and write a single template file.
+
+    Parameters
+    ----------
+    input_path
+        Path to the JSON template to read.
+    output_path
+        Explicit output path (``None`` when *in_place* is True or when
+        using the default ``.new.json`` suffix).
+    in_place
+        If True, overwrite *input_path* with the converted content.
+    """
+    with input_path.open("r", encoding="utf-8") as fh:
+        template: dict[str, Any] = json.load(fh)
+
+    converted = convert_template(template)
+
+    dest: Path
+    if in_place:
+        dest = input_path
+    elif output_path is not None:
+        dest = output_path
+    else:
+        dest = input_path.with_suffix("").with_suffix(".new.json")
+
+    with dest.open("w", encoding="utf-8") as fh:
+        json.dump(converted, fh, indent=2)
+        fh.write("\n")
+
+    print(f"Converted: {input_path} -> {dest}")
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert protocol_qc template JSON files from the pre-PR#42 "
+            "field-specification format to the updated format."
+        )
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        type=Path,
+        metavar="PATH",
+        help=(
+            "One or more template JSON files (or directories containing them) "
+            "to convert."
+        ),
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--in-place",
+        action="store_true",
+        default=False,
+        help=(
+            "Overwrite each input file with the converted content. "
+            "Cannot be used with --output."
+        ),
+    )
+    mode.add_argument(
+        "--output",
+        type=Path,
+        metavar="PATH",
+        default=None,
+        help=(
+            "Write converted output to this path. "
+            "Only valid when a single input file is given. "
+            "Cannot be used with --in-place."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+
+    # Gather all JSON files from the provided inputs
+    input_files: list[Path] = []
+    for path in args.inputs:
+        if not path.exists():
+            print(f"ERROR: path does not exist: {path}", file=sys.stderr)
+            return 1
+        if path.is_dir():
+            input_files.extend(sorted(path.glob("*.json")))
+        elif path.suffix == ".json":
+            input_files.append(path)
+        else:
+            print(f"ERROR: not a JSON file: {path}", file=sys.stderr)
+            return 1
+
+    if not input_files:
+        print("ERROR: no JSON files found in the provided inputs.", file=sys.stderr)
+        return 1
+
+    if args.output is not None and len(input_files) > 1:
+        print(
+            "ERROR: --output can only be used with a single input file.",
+            file=sys.stderr,
+        )
+        return 1
+
+    for file in input_files:
+        try:
+            _process_file(file, args.output, args.in_place)
+        except (json.JSONDecodeError, KeyError, ValueError) as exc:
+            print(f"ERROR processing {file}: {exc}", file=sys.stderr)
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/protocol_qc/generate_tags.py
+++ b/src/protocol_qc/generate_tags.py
@@ -66,23 +66,31 @@ def gen_custom_tags(
                 tags_output["custom_tags"][tag_type] = "NOT FOUND"
         elif isinstance(value["tag"], dict):
             for tag, to_check in value["tag"].items():
-                if "PRIVATE-" in to_check["field"]:
+                field_name: str = to_check["field"]
+                if "PRIVATE-" in field_name:
                     raise KeyError(
                         "Cannot use private DICOM fields when generating tags"
                     )
+                comparison_items = {k: v for k, v in to_check.items() if k != "field"}
+                if len(comparison_items) != 1:
+                    raise KeyError(
+                        f"Malformed template: tag \"{tag_type}\" option \"{tag}\""
+                        " must have exactly one comparison key besides \"field\""
+                    )
+                comparison_name, reference = next(iter(comparison_items.items()))
                 try:
-                    if attr := getattr(data_series.data, to_check["field"]):
-                        if to_check["comparison"] == "exact":
-                            if attr == to_check["value"]:
+                    if attr := getattr(data_series.data, field_name):
+                        if comparison_name == "exactly":
+                            if attr == reference:
                                 break
-                        elif to_check["comparison"] == "in_set":
-                            if attr in to_check["value"]:
+                        elif comparison_name == "in_set":
+                            if attr in reference:
                                 break
-                        elif to_check["comparison"] == "regex":
-                            if re.search(to_check["value"], attr):
+                        elif comparison_name == "regex":
+                            if re.search(reference, attr):
                                 break
-                        elif to_check["comparison"] == "in_range":
-                            if to_check["value"][0] <= float(attr) <= to_check["value"]:
+                        elif comparison_name == "in_range":
+                            if reference[0] <= float(attr) <= reference[1]:
                                 break
                 except AttributeError:
                     pass


### PR DESCRIPTION
Closes #19.
Closes #18.
Closes #15.

-----

@aaroncapon Here's a go at changing the syntax with which protocol templates define expected DICOM header content. IMO it makes the content far more readable and navigable.

What I'm not sure about is whether this kind of syntax may prove to be a hindrance in attempting to implement more complex logic. For instance, adding Boolean logic trying to support both class and enhanced DICOMs win a single template by saying "either match this set of fields, or match this set of fields".

Indeed the `"exactly_if_present"` is a bit of a shortcut in this regard. It's technically an "or" operation across an `"absent": null` and `"exactly": #####`. That is probably a common enough use case (particularly for defining fields at the protocol level even if they're absent in Phoenix) to keep it as-is rather than necessitating the implementation of Boolean logic. But it perhaps highlights the potential utility in expanding capability in that direction.

Also this should hopefully yield more sensible ordering of series mismatches as input series for which `ImageType` is "closer" to the template should rank more highly than one with many mismatched items in that list.

Posting as draft PR. Happy to discuss, rename, whatever suits.
