### PR TITLE
Improve codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,9 +31,8 @@ repos:
         name: isort (python)
         args: [--settings-path, pyproject.toml]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:
           - tomli
-        args: [--skip, conftest.py]

--- a/docs/building_a_template.md
+++ b/docs/building_a_template.md
@@ -94,7 +94,7 @@ unless the "share_fields" flag has been set (see [Special Keys](#special-keys)).
 Often important information is stored in so-called *private* tags in the DICOM header (https://dicom.nema.org/dicom/2013/output/chtml/part05/sect_7.8.html).
 Currently a very limited number of these tags are available and differ between classic and enhanced DICOMS.
 
-For classic DICOMS the folllowing are available using the following keys:
+For classic DICOMS the following are available using the following keys:
 - `PRIVATE-AcquisitionDuration` = `0x0051,0x100a`
 - `PRIVATE-CoilElementsUsed` = `0x0051,0x100f`
 - `PRIVATE-GradientMode` = `0x0019,0x100f`
@@ -136,7 +136,7 @@ The following table summarises these keys.
 - *duplicates_allowed*: Set to true if the presence of duplicates for a given acquisition should not raise an error.
 - *duplicates_expected*: If duplicate acquisitions are expected, this value can be set to an integer and will result in an error in protocol matching if the number of found duplicates does not match the template.
 - *paired_fmaps*: Dictionary to describe if and how fmaps are expected to be paired with the acquisition. See [Paired field maps](#Paired-field-maps) for more details.
-- *ignore_ordering*: Exclude an *acquistion* from the final protocol ordering check.
+- *ignore_ordering*: Exclude an *acquisition* from the final protocol ordering check.
 - *is_optional*: Use to indicate if an acquisition need not be included in the data.
 - *num_files*: Use to determine if the complete data was sent by specifying the number of expected DICOM files per series. See [Data completeness](#data-completeness) for more details on this topic.
 
@@ -211,7 +211,7 @@ field to check, the value to check it against, as well as the comparison method.
 
 In the following example, the *tags* section of a protocol template is shown.
 The `protocol_version` and `scanner_type` tags use the `constant` method and therefore will always be generated,
-and have the values `v42` and `Apeture Science`, respectively.
+and have the values `v42` and `Aperture Science`, respectively.
 The tag `scanner_software` uses the `fill_with` method, and will be extracted from the DICOM header field `SoftwareVersions`.
 If it does not exist, "NOT FOUND" will be set.
 Finally, the tag `site` uses the `options` method.
@@ -227,7 +227,7 @@ In this case, the DICOM header field `InsitutationName` is being checked, with t
       },
       "scanner_type": {
         "type": "constant",
-        "tag": "Apeture Science"
+        "tag": "Aperture Science"
       },
       "scanner_software": {
         "type": "fill_with",
@@ -273,7 +273,7 @@ In this case, the DICOM header field `InsitutationName` is being checked, with t
   },
   "custom_tags": {
     "protocol_version": "v42",
-    "scanner": "Apeture Science",
+    "scanner": "Aperture Science",
     "scanner_software": "GLaDOS",
     "site": "Earth"
   },

--- a/docs/example_template.json
+++ b/docs/example_template.json
@@ -17,7 +17,7 @@
       },
       "scanner_type": {
         "type": "constant",
-        "tag": "Apeture Science"
+        "tag": "Aperture Science"
       },
       "scanner_software": {
         "type": "fill_with",

--- a/docs/tutorial/01_firsttemplate.md
+++ b/docs/tutorial/01_firsttemplate.md
@@ -75,7 +75,7 @@ Every item in this list represents a single *acquisition*.
 It is presented at the scanner console for configuration and execution,
 and once executed takes some duration of time to acquire data.
 
-Now contrast ths against the set of sub-directories containing the images generated from execution of the session protocol:
+Now contrast this against the set of sub-directories containing the images generated from execution of the session protocol:
 
 ```sh
 ls data/Template/

--- a/docs/tutorial/02_seriesdescription.md
+++ b/docs/tutorial/02_seriesdescription.md
@@ -3,7 +3,7 @@
 ### Observations from outcomes of first working version
 
 From the initial results of executing the software
-showin in document [`01_firsttemplate.md`](01_firsttemplate.md),
+showing in document [`01_firsttemplate.md`](01_firsttemplate.md),
 there are several conclusions to be drawn
 that will inform how the template should be initially modified.
 

--- a/docs/tutorial/04_additional.md
+++ b/docs/tutorial/04_additional.md
@@ -22,9 +22,9 @@ it is the role of the ProtocolQC software
 (and the designer of the protocol template)
 to diagnose the deviations within these datasets.
 
-Docuemntation page [`sessions/README.md`](sessions/README.md)
+Documentation page [`sessions/README.md`](sessions/README.md)
 provides a list of these sessions,
-linking to individual pages per sesions
+linking to individual pages per sessions
 that explain what the software reports in each instance,
 how to interpret those results,
 and the nature of the actual deviations

--- a/docs/tutorial/sessions/007.md
+++ b/docs/tutorial/sessions/007.md
@@ -86,7 +86,7 @@ INFO No check for paired fmaps requested.
 INFO ------------------------------------------------------------------------------------------------------------------------------------------
 ```
 
-The softwares fails to comprehensively match
+The software fails to comprehensively match
 the T2*-weighted multi-echo gradient sequence.
 While the first three image series for that acquisition are matched without issue,
 the fourth only achieves partial matches to input series.

--- a/docs/tutorial/sessions/013.md
+++ b/docs/tutorial/sessions/013.md
@@ -180,7 +180,7 @@ Depending on the circumstances in which such a series arises,
 a user of the software could choose to either:
 
 -   Leave the protocol template unaltered,
-    therfore having such series appropriately flagged as unexpected
+    therefore having such series appropriately flagged as unexpected
     for any datasets in which they are encountered;
 
 -   Include such an acquisition within the protocol template,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,3 +94,10 @@ addopts = "--cov-report term-missing --cov=protocol_qc"
 testpaths = [
     "tests"
 ]
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ testpaths = [
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git*'
+skip = '.git*,conftest.py'
 check-hidden = true
 # ignore-regex = ''
-# ignore-words-list = ''
+ignore-words-list = 'nd,te'

--- a/src/protocol_qc/classes/protocol.py
+++ b/src/protocol_qc/classes/protocol.py
@@ -219,7 +219,7 @@ class TemplateProtocol:
 
     def _set_paired_fmap_defaults(self) -> None:
         """
-        Set the paired fmap defaults for the template procotol.
+        Set the paired fmap defaults for the template protocol.
         """
 
         self.paired_fmaps = {

--- a/src/protocol_qc/classes/series.py
+++ b/src/protocol_qc/classes/series.py
@@ -686,7 +686,7 @@ class TemplateSeries:
         Parameters
         ----------
         field
-            Value of the user specified field from template procotol.
+            Value of the user specified field from template protocol.
         attribute
             Corresponding value of the field from a DICOM series.
 
@@ -712,7 +712,7 @@ class TemplateSeries:
         Parameters
         ----------
         field
-            Value of the user specified field from template procotol.
+            Value of the user specified field from template protocol.
         attribute
             Corresponding value of the field from a DICOM series.
 
@@ -753,7 +753,7 @@ class TemplateSeries:
         Parameters
         ----------
         field
-            Value of the user specified field from template procotol.
+            Value of the user specified field from template protocol.
         attribute
             Corresponding value of the field from a DICOM series.
 
@@ -791,7 +791,7 @@ class TemplateSeries:
         Parameters
         ----------
         field
-            Value of the user specified field from template procotol.
+            Value of the user specified field from template protocol.
         attribute
             Corresponding value of the field from a DICOM series.
 


### PR DESCRIPTION
It was already known to pre-commit but older version and not all typos were fixed. Also there were no centralized configuration in default location so running `codespell` was bringing false positives.

CI workflow has 'permissions' set only to 'read' so also should be safe.  I think having this workflow *in addition* to pre-commit would only be beneficial since annotates in the diff right here on github.