### PR TITLE
Simplify template specification of number of files

### DIFF
--- a/docs/building_a_template.md
+++ b/docs/building_a_template.md
@@ -140,7 +140,7 @@ The following table summarises these keys.
 | *ignore_ordering*      | bool         | no       | False   |
 | *series*               | dict         | yes      | -       |
 | **Series Level**                                           |
-| *num_files*            | int          | no       | None    |
+| *num_files*            | tuple[int,int] or int | no       | None    |
 | *share_fields*         | bool         | no       | True    |
 
 - *allow_extra*: If true, the presence of additional (unmatched) series will not be treated as an issue with the data.
@@ -159,7 +159,8 @@ The following table summarises these keys.
 There are number of ways to ensure the complete data set for each series was sent, however the approach varies
 depending on the type of data (classic, enhanced, MOSAIC etc).
 
-For classic DICOM data with one slice per file, specifying the number of slices is sufficient.\
+For classic DICOM data with one slice per file, specifying the number of slices (using "num_files") is sufficient.
+A range can also be set in the template if the number of slices can vary.\
 For data stored in MOSAIC format, the number of slices in conjunction with the series level *field* entry "NumberofImagesInMosaic" can be utilised.\
 When checking enhanced DICOMS, the "NumberOfFrames" *field* should be used.
 

--- a/src/protocol_qc/build_templates.py
+++ b/src/protocol_qc/build_templates.py
@@ -153,7 +153,7 @@ def get_num_files(fields_series: dict[str, Any]) -> tuple[int, ...] | int | None
         If number of files is incorrectly specified.
     """
 
-    exp_num_files: dict[str, int] | int | None = fields_series.pop("num_files", None)
+    exp_num_files: list[int] | int | None = fields_series.pop("num_files", None)
 
     num_files: tuple[int, ...] | int | None
     if not exp_num_files:
@@ -161,12 +161,13 @@ def get_num_files(fields_series: dict[str, Any]) -> tuple[int, ...] | int | None
         num_files = exp_num_files
     elif isinstance(exp_num_files, int):
         num_files = exp_num_files
-    elif isinstance(exp_num_files, dict):
-        num_files = tuple([exp_num_files["min"], exp_num_files["max"]])
+    elif isinstance(exp_num_files, list):
+        num_files = tuple(exp_num_files)
     else:
         raise ValueError(
             "Expected number of files must be specified as either an int or "
-            "a dict containing 'min' and 'max' keys. Please check template."
+            f"a list containing min and max values. Recieved: {type(exp_num_files)}. "
+            "Please check template."
         )
 
     return num_files

--- a/src/protocol_qc/classes/series.py
+++ b/src/protocol_qc/classes/series.py
@@ -332,13 +332,13 @@ class TemplateSeries:
             Is the series complete?
         """
 
-        num_files: tuple[int, ...] | int | None
+        num_files: tuple[int, int] | int | None
         if num_files := getattr(self, "num_files"):
             if isinstance(num_files, tuple):
                 if not (
-                    len(num_files) == 2 \
-                    and isinstance(num_files[0], int) \
-                    and isinstance(num_files[1], int) \
+                    len(num_files) == 2
+                    and isinstance(num_files[0], int)
+                    and isinstance(num_files[1], int)
                 ):
                     raise TypeError(
                         "Malformed template:"
@@ -351,6 +351,7 @@ class TemplateSeries:
                 self.logger.error(
                     f"   files: {scan.num_files} not between {list(num_files)}"
                 )
+                return False
             if not isinstance(num_files, int):
                 raise TypeError(
                     "Malformed template:"

--- a/src/protocol_qc/convert_template.py
+++ b/src/protocol_qc/convert_template.py
@@ -229,6 +229,15 @@ def _convert_node(node: Any) -> Any:
             result[key] = _convert_tags_block(value)
         elif key == "fields" and isinstance(value, dict):
             result[key] = _convert_fields_block(value)
+        elif key == "num_files" and isinstance(value, dict):
+            if "min" in value and "max" in value:
+                result[key] = [value["min"], value["max"]]
+            else:
+                raise ValueError(
+                    "'min' and/or 'max' keys missing from 'num_files' dictionary. "
+                    "Unclear how to convert. Please ensure both bounds are set in "
+                    "original templates before trying to convert."
+                )
         elif isinstance(value, dict):
             result[key] = _convert_node(value)
         elif isinstance(value, list):


### PR DESCRIPTION
Further simplify the templates by having a range of files specified simply with a list rather than a dictionary.

- Updates protocol_qc package as well as script to convert from old to new templates